### PR TITLE
Bugfix: Schema Registry API Tutorial environment JSON

### DIFF
--- a/postman/schema_editor_tutorial/Schema Registry API Tutorial.postman_environment.json
+++ b/postman/schema_editor_tutorial/Schema Registry API Tutorial.postman_environment.json
@@ -58,5 +58,5 @@
       "enabled": true
     }
   ],
-  "_postman_variable_scope": "environment",
+  "_postman_variable_scope": "environment"
 }


### PR DESCRIPTION
Experience Platform tutorial for creating a schema using the Schema Registry API contains a link to the postman environment. A recent update removed lines from the JSON and left an errant comma in line 61. This PR will remove that comma and should stop the JSON from returning errors when the link is clicked.

Tutorial link: https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/schema_registry_api_tutorial/schema_registry_api_tutorial.md 

JSON link in tutorial: https://raw.githubusercontent.com/adobe/experience-platform-postman-samples/master/postman/schema_editor_tutorial/Schema%20Registry%20API%20Tutorial.postman_environment.json#