### PR TITLE
Postman collections generated from Swagger specs (2020-03-23 20:40)

### DIFF
--- a/apis/experience-platform/Access Control API.postman_collection.json
+++ b/apis/experience-platform/Access Control API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f6417c0c-7a64-496b-8cc5-ae70f0f050c3",
+		"_postman_id": "2ea6510b-6336-53a2-a938-47d7b70f6464",
 		"name": "Access Control API",
 		"description": "Access Control in Adobe Experience Platform allows IMS Organization administration to assign roles and permissions for various Platform capabilities. The Access Control API provides a public endpoint to retrieve effective policies for a user on given resources within a specified sandbox. All other access control capabilities are provided through the [Adobe Admin Console](https://adminconsole.adobe.com).\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io\n  * Base path for this API: /data/foundation/access-control\n  * Example of a complete path for making a call to \"/acl/effective-policies\": https://<span>platform.adobe.io/data/foundation/access-control/acl/effective-policies\n\nRequired headers:\n  * All service calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these, see the <a href=\"https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md\">authentication tutorial</a>.\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "4ee33fa2-4a48-42d0-aa18-20582cddf4df",
+					"_postman_id": "74ee6b5f-7987-5287-9980-363044688225",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -123,13 +123,13 @@
 							}
 						}
 					],
-					"_postman_id": "aedba177-4ac0-4e31-b325-dc52d0d294b3",
+					"_postman_id": "28998416-4d62-5dd5-8e3c-7baabfdf5997",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -184,7 +184,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "39a5b38e-f7e6-4722-9ed7-bbf2d50ea5d3",
+			"_postman_id": "9be1e448-46b3-5541-8ef5-9572e4231d49",
 			"description": "Folder for Access Control Policies"
 		}
 	]

--- a/apis/experience-platform/Catalog Service API.postman_collection.json
+++ b/apis/experience-platform/Catalog Service API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c9f4aa6f-c8f5-4733-b66f-950c9e05eb33",
+		"_postman_id": "22fa8ce1-a2b7-5878-9e4a-0ae65e8868dd",
 		"name": "Catalog Service API",
 		"description": "Catalog is the system of record for data location and lineage within Adobe Experience Platform. Catalog is not the actual files or directories containing data, rather it holds the metadata and description of those files and directories.\n\nSimply put, Catalog acts as a metadata store or \"catalog\" where you can find information about your data within Experience Platform.\n\nYou can use Catalog to answer questions such as, where is my data located? at what stage of processing is this data? what systems or processes have acted on my data? what errors occurred during processing? and, if successful, how much data was processed?\n\nRelated documentation:\n  * [Catalog Service overview](https://www.adobe.io/apis/experienceplatform/home/services/allservices.html#!api-specification/markdown/narrative/technical_overview/catalog_architectural_overview/catalog_architectural_overview.md)\n  * [Create a dataset using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/creating_a_dataset_tutorial/creating_a_dataset_tutorial.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Catalog Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Catalog%20Service%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/catalog\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/catalog/batches\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "c5c602ed-b8df-46ca-92a3-42c394f7adc0",
+					"_postman_id": "9b85c9e0-89bb-54a5-8b6a-f914ee3995a6",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -183,13 +183,13 @@
 							}
 						}
 					],
-					"_postman_id": "619846ea-28e7-49a1-8fd4-972e184d81f4",
+					"_postman_id": "d127c8bd-1b53-5c61-a9a2-2fda85b540e2",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -280,13 +280,13 @@
 							}
 						}
 					],
-					"_postman_id": "b4557a8e-2c11-4fb9-adc9-2cf485718eac",
+					"_postman_id": "d73dcf59-c6ff-566b-bd71-9bb53b77fe56",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -380,13 +380,13 @@
 							}
 						}
 					],
-					"_postman_id": "e5c83cd8-763f-4e63-888a-8547524f4a96",
+					"_postman_id": "562b33fc-37db-51a1-bda3-74e454d2f533",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -484,13 +484,13 @@
 							}
 						}
 					],
-					"_postman_id": "c7723ea2-668e-4102-86a7-a57de4d42fc8",
+					"_postman_id": "b840411c-7ac2-5b30-944a-b0c961af5d45",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -588,13 +588,13 @@
 							}
 						}
 					],
-					"_postman_id": "ed5965af-26dd-4d81-b57a-506b453511e7",
+					"_postman_id": "7a57f303-b7ac-5a3e-a4a4-f282c107d09d",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -692,13 +692,13 @@
 							}
 						}
 					],
-					"_postman_id": "fc6a05c5-6cb5-4494-b211-c29923ce22be",
+					"_postman_id": "0d12984f-a7cd-5e68-a5cd-1b71c0af9670",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -770,7 +770,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "81469030-f6c4-422e-aa13-fe48f3443659",
+			"_postman_id": "902e3a8c-97cd-5ad9-98d2-c29e42ef6e74",
 			"description": "Accounts represent a collection of authentication credentials used to create data connections of a specific type. Each connection has a set of unique parameters that are persisted by Catalog and secured in an Azure Key Vault using Security Services."
 		},
 		{
@@ -803,13 +803,13 @@
 							}
 						}
 					],
-					"_postman_id": "0a4ffd99-8e12-476d-bd1f-1345fb7044da",
+					"_postman_id": "4204c742-5d04-5c1a-bfae-ebbba8ea9c9c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -970,13 +970,13 @@
 							}
 						}
 					],
-					"_postman_id": "37c6ac57-feb2-43ef-aa96-771200a9282c",
+					"_postman_id": "e292cea7-2daa-593e-b89d-7cfdcf52bf1a",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1067,13 +1067,13 @@
 							}
 						}
 					],
-					"_postman_id": "bae9cbcd-f921-4a83-b497-32a753d84df6",
+					"_postman_id": "11db7faa-8a7e-5a57-a9b9-a3ad2273593d",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1242,13 +1242,13 @@
 							}
 						}
 					],
-					"_postman_id": "5052fd2c-2f45-4139-ad0b-80e9a8355131",
+					"_postman_id": "77b551a7-c3bc-5a90-b53f-a76f6d16d867",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1348,13 +1348,13 @@
 							}
 						}
 					],
-					"_postman_id": "44e7f666-a893-432c-a356-f3d283202f74",
+					"_postman_id": "457f70fd-d0a2-547d-862a-52c4fb2e2476",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1452,13 +1452,13 @@
 							}
 						}
 					],
-					"_postman_id": "b9f830fd-eca2-4a6e-8fec-0ff48171a344",
+					"_postman_id": "bdaad6b0-bb54-5223-8bfd-08721e27a1be",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1556,13 +1556,13 @@
 							}
 						}
 					],
-					"_postman_id": "f925f9b7-b9f7-43e5-9e61-b5d42784e368",
+					"_postman_id": "e2c2fa8a-02f9-5cb7-a92d-a3279b4b9196",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1660,13 +1660,13 @@
 							}
 						}
 					],
-					"_postman_id": "e476a4e0-eeb5-4f8a-8769-a67c35b74142",
+					"_postman_id": "5ecb4430-4899-5dd2-bf3d-b1affbec0e8f",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1738,7 +1738,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "c7bceb18-944c-4d8f-8848-5c3e6c81a37e",
+			"_postman_id": "0fbdfdca-0140-5ceb-bd71-5dc6783a9437",
 			"description": "Batches allow Catalog users to understand which operations and applications have been performed on objects tracked by the system. A batch outlines the final results of an operation (such as records processed, or size on disk) but may also include links to datasets, files, and more that were affected by the process."
 		},
 		{
@@ -1771,13 +1771,13 @@
 							}
 						}
 					],
-					"_postman_id": "a23b2643-fe89-496a-8335-bb842df9c712",
+					"_postman_id": "b60fe4cc-ee66-5c1c-b2f9-207f22a971c3",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1845,7 +1845,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "65b6b49b-372d-4866-940f-701692113083",
+			"_postman_id": "7eb048d1-8978-5f57-9b31-09a084e8088e",
 			"description": "Large documents are ingested files that exceed 512MB in size. These files are divided into chunks and ingested separately."
 		},
 		{
@@ -1878,13 +1878,13 @@
 							}
 						}
 					],
-					"_postman_id": "1d624a5f-02e9-4337-a1ef-da3fdbf9e3a1",
+					"_postman_id": "2a9e16cc-8e89-5dd6-a366-6d75cb085aea",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2001,13 +2001,13 @@
 							}
 						}
 					],
-					"_postman_id": "787113f6-977a-40b0-84a6-df20819b7095",
+					"_postman_id": "6107690d-e0d1-5761-a04d-41996a51838e",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2098,13 +2098,13 @@
 							}
 						}
 					],
-					"_postman_id": "0bc53b9e-8aae-45fe-98e9-1e393aa2b037",
+					"_postman_id": "5513d7bd-b7f7-5def-b980-487bbb73cee8",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2198,13 +2198,13 @@
 							}
 						}
 					],
-					"_postman_id": "2fcc8719-8196-4bd0-97ee-aea39d829541",
+					"_postman_id": "9dfaa69e-354e-5624-b4b0-3c30c571ddab",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2302,13 +2302,13 @@
 							}
 						}
 					],
-					"_postman_id": "08d4ad0a-ea40-41cf-b516-79c347e1401e",
+					"_postman_id": "a0d496f0-efa7-5c71-8c0b-0807a0c093e6",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2406,13 +2406,13 @@
 							}
 						}
 					],
-					"_postman_id": "47bc1f5e-5f61-4205-8518-187c3971affe",
+					"_postman_id": "c8f78445-c30d-5210-818f-ad2b711705b8",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2510,13 +2510,13 @@
 							}
 						}
 					],
-					"_postman_id": "26c0f08d-4678-4a2a-8870-8320693654bd",
+					"_postman_id": "acf2d29d-033a-5831-b838-51c4e1d305b6",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2610,13 +2610,13 @@
 							}
 						}
 					],
-					"_postman_id": "81d45e8a-09bb-4777-9eda-79c5757dfe5d",
+					"_postman_id": "c39a40cd-c13a-598a-8cd3-538b91ffa47f",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2685,7 +2685,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "f17a1132-2f8b-4f5a-bcdb-58d13170b8b8",
+			"_postman_id": "b1c104bc-0952-5cac-a67a-0a0787de4018",
 			"description": "Connections are customer-specific instances of connectors. As an example, when a user selects the Azure Blob connector and supplies the necessary details as defined by that connector, the result is a connection."
 		},
 		{
@@ -2718,13 +2718,13 @@
 							}
 						}
 					],
-					"_postman_id": "61961c11-6bc8-455c-aa83-a5a36e735c52",
+					"_postman_id": "37b146c9-81d0-56bc-8d67-814451c9e17d",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2849,13 +2849,13 @@
 							}
 						}
 					],
-					"_postman_id": "373eb4b5-ee7f-44cd-a1f0-45855ba30f4a",
+					"_postman_id": "72ddb59a-ed29-5bfa-a721-101f55ff6edf",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2949,13 +2949,13 @@
 							}
 						}
 					],
-					"_postman_id": "65723e4a-bc44-4654-b173-01e7486f5f5a",
+					"_postman_id": "babe4a66-a24d-5bc2-ae55-d3cdd62926b2",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3024,7 +3024,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "10921ccc-d92c-469b-b586-9779d69bb947",
+			"_postman_id": "f862766e-4194-5384-bb33-daf535448680",
 			"description": "Connectors define how and when data is ingested into Platform. They control how data is to be gathered from technology sources (like S3, RedShift, and SFTP) and partner sources (like DFA, SAP, MSFT, and ExactTarget). Connectors also define how and when data from Adobe solutions is ingested into Platform."
 		},
 		{
@@ -3057,13 +3057,13 @@
 							}
 						}
 					],
-					"_postman_id": "0dc0714e-f033-4cd3-90eb-751d10a1c68d",
+					"_postman_id": "709e7e6a-0eab-5f18-ab33-bb6fd44c9f73",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3180,13 +3180,13 @@
 							}
 						}
 					],
-					"_postman_id": "aa49ff7a-665f-4c81-b176-89203b278c9f",
+					"_postman_id": "672e74ea-be1e-5425-864c-d344a9b4be05",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3283,13 +3283,13 @@
 							}
 						}
 					],
-					"_postman_id": "f85c5010-835b-48ca-9df1-c1f900e0f593",
+					"_postman_id": "1c978246-49e3-5113-af78-fb920a29b041",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3389,13 +3389,13 @@
 							}
 						}
 					],
-					"_postman_id": "c46af9b4-ac16-442f-80f2-d994a267a194",
+					"_postman_id": "1864fcfe-51c3-5c57-9018-c1e0542e5691",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3499,13 +3499,13 @@
 							}
 						}
 					],
-					"_postman_id": "92912053-90d4-4999-8ad3-1b689a6ef356",
+					"_postman_id": "99b88002-9352-5d1b-98bc-3f4896c6d886",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3603,13 +3603,13 @@
 							}
 						}
 					],
-					"_postman_id": "e0a65653-15a1-4c92-8101-4afc04525c25",
+					"_postman_id": "c0c1a269-05ce-55ce-823a-93fe51fc604c",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3707,13 +3707,13 @@
 							}
 						}
 					],
-					"_postman_id": "0541f3a5-0467-4ef9-9f2d-a7f80d5f5613",
+					"_postman_id": "69b48767-ae2a-5817-9deb-48b646226773",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3821,13 +3821,13 @@
 							}
 						}
 					],
-					"_postman_id": "a3276069-6a87-4c43-825b-a3fdf03fa378",
+					"_postman_id": "f82990fe-4caf-5a0b-92b4-4aa2f0dd198f",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3922,13 +3922,13 @@
 							}
 						}
 					],
-					"_postman_id": "4d56f369-0636-4a28-8518-8752e95b701c",
+					"_postman_id": "a7e5204c-3321-545e-9998-803ec236d05d",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -4027,13 +4027,13 @@
 							}
 						}
 					],
-					"_postman_id": "761d19b5-2da4-4371-a487-8149b9146331",
+					"_postman_id": "0dff1a00-4367-5b53-ad8e-3b28f69c1a9b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4133,13 +4133,13 @@
 							}
 						}
 					],
-					"_postman_id": "e15adab7-1fd0-40bb-8087-475bdef93ec4",
+					"_postman_id": "1421e6f5-3d83-5328-9f70-e966f32f40a5",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4240,13 +4240,13 @@
 							}
 						}
 					],
-					"_postman_id": "096de2ee-9319-4430-b771-246e4c2fd6cc",
+					"_postman_id": "1cdaae85-dddd-5b43-b45e-febfe456d72b",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -4351,13 +4351,13 @@
 							}
 						}
 					],
-					"_postman_id": "52122e67-ab97-44f5-87c6-9886287f19a9",
+					"_postman_id": "b0c45f3f-ec99-51ad-9379-a6c128c376b5",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4463,13 +4463,13 @@
 							}
 						}
 					],
-					"_postman_id": "53c6a5fa-0e7a-4904-b3f7-819356ce1579",
+					"_postman_id": "ef0b1a84-ee2a-58cc-a335-662b3045022a",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4575,13 +4575,13 @@
 							}
 						}
 					],
-					"_postman_id": "a61b8289-5884-4463-81f7-a078be5709b5",
+					"_postman_id": "fab4fa75-34e6-50d0-85b0-9901a18c9ec2",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4676,13 +4676,13 @@
 							}
 						}
 					],
-					"_postman_id": "31b35027-f707-4520-95e6-894c3df469f0",
+					"_postman_id": "e33cd921-351e-5a87-ac22-38adadaebfd2",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4751,7 +4751,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "35b36649-c76f-4833-8e02-773d9605e91f",
+			"_postman_id": "17400542-ee74-547c-aab8-18d6bc9dd2b8",
 			"description": "Datasets are the building blocks for data transformation and tracking in Catalog Service. Generally, datasets represent a table or file made available by a connection."
 		},
 		{
@@ -4784,13 +4784,13 @@
 							}
 						}
 					],
-					"_postman_id": "b359984f-92cd-4575-b5f8-723be8d42bd6",
+					"_postman_id": "6ec9161b-f47c-5676-86f7-acd395525e78",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4923,13 +4923,13 @@
 							}
 						}
 					],
-					"_postman_id": "65d13007-3e79-4a72-8bb8-e80d4208fdc1",
+					"_postman_id": "12e1537f-9f58-5d6d-9970-c557ba118eef",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -5020,13 +5020,13 @@
 							}
 						}
 					],
-					"_postman_id": "5573d661-a59c-41f8-b310-a3a58729f02c",
+					"_postman_id": "001a0776-fb84-519f-87c6-fa1cad8ce453",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5126,13 +5126,13 @@
 							}
 						}
 					],
-					"_postman_id": "e845f742-0fbd-4993-b919-4c585c46772e",
+					"_postman_id": "06d3f72d-56a3-5e12-92ba-4f7fd09d3a79",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -5230,13 +5230,13 @@
 							}
 						}
 					],
-					"_postman_id": "c2f8a7d2-1cb8-4ddc-a189-31013eaf82b0",
+					"_postman_id": "65fb571b-82e2-529d-abb8-85d0bfbe385a",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -5334,13 +5334,13 @@
 							}
 						}
 					],
-					"_postman_id": "b9a2b7f3-2d2b-40dc-bd8d-486671f58288",
+					"_postman_id": "c2647b19-4b59-5af1-8379-594fd57ad6ef",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5408,7 +5408,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "26840f0b-4397-4319-8911-e03c02980bca",
+			"_postman_id": "de371196-bada-51d6-a74d-9af3dcbff5c3",
 			"description": "Folder for Dataset views"
 		},
 		{
@@ -5441,13 +5441,13 @@
 							}
 						}
 					],
-					"_postman_id": "1d0f2765-b97d-4580-9260-42777cdb86f1",
+					"_postman_id": "3f44573c-6ce7-5f2b-8f45-89a58668d826",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5560,13 +5560,13 @@
 							}
 						}
 					],
-					"_postman_id": "6d5940cb-bfa5-4c05-ac2d-e74953bf2d0f",
+					"_postman_id": "7bd6915d-4b8f-5d3e-a754-fe93371e4e2c",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -5657,13 +5657,13 @@
 							}
 						}
 					],
-					"_postman_id": "e7054042-c220-43fd-8759-ad39deb9e35b",
+					"_postman_id": "edcbe2e7-979b-5355-ac93-31aea2d63758",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5756,13 +5756,13 @@
 							}
 						}
 					],
-					"_postman_id": "e8b188a2-75fb-450b-bced-ccc949c342ce",
+					"_postman_id": "a11dec5d-09bd-5d38-bed9-6d0da60a2b97",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5856,13 +5856,13 @@
 							}
 						}
 					],
-					"_postman_id": "2fc40512-692b-460a-9c3a-629885edded6",
+					"_postman_id": "a576ac3c-a413-5100-ac8d-24cc64b79e67",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -5960,13 +5960,13 @@
 							}
 						}
 					],
-					"_postman_id": "b3642f46-9a5f-43f4-aade-b4e5837addb0",
+					"_postman_id": "663b0652-5d81-54c1-a49c-8f6a95683873",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -6064,13 +6064,13 @@
 							}
 						}
 					],
-					"_postman_id": "dc821e43-1cac-47d6-ba92-1caa050115b4",
+					"_postman_id": "953976d7-f59a-59f3-b530-7a0adb046b24",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6138,7 +6138,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "8b4900f8-e07f-4ebb-9568-a5a1a8f5e689",
+			"_postman_id": "173ae765-7c8a-569f-b999-8d2ae4f3cbb5",
 			"description": "Dataset files represent blocks of data that have been saved on Platform. As records of literal files, these are where you can find the file size and which batch the file came from. This construct will also provide the number of records contained in the file."
 		},
 		{
@@ -6171,13 +6171,13 @@
 							}
 						}
 					],
-					"_postman_id": "994a72fd-6180-48f6-ad3e-a7c9814bc491",
+					"_postman_id": "e77c9d20-02b4-5edf-bc7a-c1f3514b2a8d",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6264,13 +6264,13 @@
 							}
 						}
 					],
-					"_postman_id": "415c573b-7ab2-4bc7-9c84-5bc7abe7ded3",
+					"_postman_id": "534b074e-37b2-515f-8c3f-0eae25c269a2",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -6335,7 +6335,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "eca063c1-8e03-4f0f-a0cf-70e1fbb3b238",
+			"_postman_id": "95a4f0e8-92b9-59f9-ac20-053718e4f5dd",
 			"description": "Batched requests allow you to supply an array of objects in the request payload, representing what would normally be individual requests. Requests are executed in order and values returned from a previous call are made available in subsequent calls through template language."
 		},
 		{
@@ -6368,13 +6368,13 @@
 							}
 						}
 					],
-					"_postman_id": "28bb0fe3-571b-45d7-be97-bf8d4bed99c6",
+					"_postman_id": "e99d1211-ac6b-5897-a668-88a3754672ae",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6491,13 +6491,13 @@
 							}
 						}
 					],
-					"_postman_id": "0ef3f571-0b55-49a0-b299-dd76d277088d",
+					"_postman_id": "deee6820-51d4-57de-adaa-dec74d689894",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -6588,13 +6588,13 @@
 							}
 						}
 					],
-					"_postman_id": "9e944f0e-8d4c-47a2-8b7b-48eae029cb23",
+					"_postman_id": "2c7711c3-2626-5cfd-a566-4d85d06872b0",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6688,13 +6688,13 @@
 							}
 						}
 					],
-					"_postman_id": "db6b426f-d763-44f0-a15d-19b8d740c4c7",
+					"_postman_id": "d868ec81-e7a8-5423-84a1-cb93ea3681e5",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -6792,13 +6792,13 @@
 							}
 						}
 					],
-					"_postman_id": "cbdfa033-c9be-474a-8fd4-339761cac722",
+					"_postman_id": "e22aae0c-129a-5aac-9b78-944323f203a1",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -6896,13 +6896,13 @@
 							}
 						}
 					],
-					"_postman_id": "90f63343-fcd2-41c7-8325-39505ba69633",
+					"_postman_id": "51e00805-37ab-5436-a37e-5047ed465ff1",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6996,13 +6996,13 @@
 							}
 						}
 					],
-					"_postman_id": "ca54aceb-f2a5-435a-8d6f-8df9e8c11a25",
+					"_postman_id": "8fb615a7-e089-54c5-ba4b-6add96195581",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -7097,13 +7097,13 @@
 							}
 						}
 					],
-					"_postman_id": "1204e429-401e-4ae0-b6b7-321b187c8c50",
+					"_postman_id": "e9854f21-0159-54bb-8877-de80ec1b7bf2",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -7202,13 +7202,13 @@
 							}
 						}
 					],
-					"_postman_id": "b3e54b8f-fd6a-4807-8f86-4a47e2fc445f",
+					"_postman_id": "80fbe4a7-9d06-5cff-b443-1ab58db9a29e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -7303,13 +7303,13 @@
 							}
 						}
 					],
-					"_postman_id": "0eea44c6-ee0f-45fa-b4dc-a1b6d24e5eca",
+					"_postman_id": "9c845566-8566-5582-85d0-0eed22598a0d",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -7408,13 +7408,13 @@
 							}
 						}
 					],
-					"_postman_id": "5d33ff7d-4c06-4459-a830-632e6e80177f",
+					"_postman_id": "98b4f0eb-f829-5a43-b7b3-88fdd059fd44",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -7514,13 +7514,13 @@
 							}
 						}
 					],
-					"_postman_id": "024fe906-ddb3-4d70-89a0-343db12b687c",
+					"_postman_id": "208fee31-fc41-5de7-86e7-93ad249642c5",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -7620,13 +7620,13 @@
 							}
 						}
 					],
-					"_postman_id": "ab126131-4ce8-46ae-9f66-048e24962d4c",
+					"_postman_id": "380fe469-cc19-52a1-ad34-bf24a76ccc87",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -7726,13 +7726,13 @@
 							}
 						}
 					],
-					"_postman_id": "d0a4f32d-ca72-44f0-9029-5422fde4e827",
+					"_postman_id": "6820e508-8557-5b67-ac99-efb937c24563",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -7806,7 +7806,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "c2ccd1ce-949e-4364-92fd-b147b63a3418",
+			"_postman_id": "07ed208c-dd6f-5c7f-b071-0eba8240f5b6",
 			"description": "Transforms are used to house the instructions that translate data into a new form. As a customer maps their newly uploaded data to an Experience Data Model (XDM) schema, a transform is created to document links to the repository where the code resides, as well as a link to the vehicle (or engine) used to perform that work."
 		},
 		{
@@ -7839,13 +7839,13 @@
 							}
 						}
 					],
-					"_postman_id": "c1dc8de1-c3bd-4c41-9c20-cafe33c4ea6e",
+					"_postman_id": "02482406-3c0e-5ed0-9ccd-7dae8c77c080",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -7913,7 +7913,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "73f13b02-84a1-408a-a03f-50edda6f4c5c",
+			"_postman_id": "f0d7af3c-491b-5e1c-bff9-faed846a2056",
 			"description": "Tags are used to attach information to an object and then be used later to retrieve the object. The choice of what tags are used and how they are applied depends on your organizational processes."
 		}
 	]

--- a/apis/experience-platform/DULE Policy Service.postman_collection.json
+++ b/apis/experience-platform/DULE Policy Service.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "167ed540-47e1-4a56-ab62-1115372f5dcf",
+		"_postman_id": "653d4fcf-2730-5157-97e9-f4f36c509f31",
 		"name": "DULE Policy Service",
 		"description": "The Data Usage Labeling and Enforcement (DULE) framework simplifies and streamlines the process of categorizing data and creating data usage policies. Once data labels have been applied and data usage policies are in place, marketing actions can be evaluated to ensure the correct use of data.\nThe Policy Service API is used to manage and evaluate policies on marketing actions in the presence of data usage labels.\n\nRelated documentation:\n  * [Data Governance overview](https://www.adobe.io/apis/experienceplatform/home/dule/duleservices.html)\n  * [Supported data usage labels](https://www.adobe.io/apis/experienceplatform/home/dule/duleservices.html#!api-specification/markdown/narrative/technical_overview/data_governance/dule_supported_labels.md)\n  * [Working with Data Usage Labels](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/dule/dule_working_with_labels.md)\n  * [DULE Policy Service developer guide](https://www.adobe.io/apis/experienceplatform/home/dule/duleservices.html#!api-specification/markdown/narrative/technical_overview/data_governance/dule_policy_service_developer_guide.md)\n  * [Create and evaluate a DULE policy](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/dule/create_a_dule_policy_tutorial.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [DULE Policy Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/DULE%20Policy%20Service.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/dulepolicy\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/dulepolicy/policies/core\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "6f842b34-4ebb-4516-ba09-536200a6536b",
+					"_postman_id": "092fa9e0-d596-5f41-9c87-0dc5cab78369",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -153,13 +153,13 @@
 							}
 						}
 					],
-					"_postman_id": "fc2833a1-de62-4ef9-8e83-1f4db41f63af",
+					"_postman_id": "74467699-69be-5cae-a0ce-baa9b8f0ca0e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -251,13 +251,13 @@
 							}
 						}
 					],
-					"_postman_id": "b2afec7f-e670-4899-b412-07d3bf9cccc3",
+					"_postman_id": "e2f78a40-315e-5c92-9fd7-a829f942357b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -335,13 +335,13 @@
 							}
 						}
 					],
-					"_postman_id": "4286a6f4-bd5f-4638-a925-7a8597af372f",
+					"_postman_id": "909b3d88-825f-5535-8e34-fda60a2084e8",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -419,13 +419,13 @@
 							}
 						}
 					],
-					"_postman_id": "6abc155d-1303-4f07-b39a-736b87d3784b",
+					"_postman_id": "a7802c01-c7b0-5b75-b8f8-b666ace6a857",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -517,13 +517,13 @@
 							}
 						}
 					],
-					"_postman_id": "aed977cf-5726-42af-ab1a-5f2f6443910f",
+					"_postman_id": "0221e6e9-0679-57d5-943d-d5e84eaa63a3",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -615,13 +615,13 @@
 							}
 						}
 					],
-					"_postman_id": "1e689099-d094-4ad8-8786-db2abcb015e2",
+					"_postman_id": "c8bb1f7c-77d9-5bc1-95f0-d8732dc4201c",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -713,13 +713,13 @@
 							}
 						}
 					],
-					"_postman_id": "a07bbc13-8cef-4369-95ea-c98ca42aba9b",
+					"_postman_id": "c7fffd64-b87d-5535-9a62-d9c7ea8e613b",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -785,7 +785,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "b0daffea-9347-4b4e-bec3-e410b6741f77",
+			"_postman_id": "20198a0f-68c8-5036-8477-751d6e9c799c",
 			"description": "Data usage policies are rules that describe the kinds of marketing actions that are allowed or not allowed to be performed on data within Adobe Experience Platform."
 		},
 		{
@@ -818,13 +818,13 @@
 							}
 						}
 					],
-					"_postman_id": "1fc8f78c-65c6-437b-9a01-9b9f91477349",
+					"_postman_id": "80600aa6-3cbd-5a07-b416-b7b0e33d7121",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -902,13 +902,13 @@
 							}
 						}
 					],
-					"_postman_id": "b45c6b8f-4ccd-4178-8ff7-c3f01ca6483e",
+					"_postman_id": "07fac60d-aa0d-518a-ba33-126fffeaf528",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1000,13 +1000,13 @@
 							}
 						}
 					],
-					"_postman_id": "7f4b847b-7cfb-4e87-9154-37988fe3da4a",
+					"_postman_id": "9ea35a28-fe23-5563-8b09-124de981bf4f",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1100,13 +1100,13 @@
 							}
 						}
 					],
-					"_postman_id": "5337680e-5c8f-49da-866f-adc7a5d392c4",
+					"_postman_id": "31e2c66c-7973-545d-b6a4-9532a402da81",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1200,13 +1200,13 @@
 							}
 						}
 					],
-					"_postman_id": "46872056-fe61-437c-9b15-0054217eaf86",
+					"_postman_id": "d97ff20d-b680-53e6-a3bc-271b26d61bea",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1284,13 +1284,13 @@
 							}
 						}
 					],
-					"_postman_id": "dff4c651-30e1-4c69-a3df-5ee78c61f1f0",
+					"_postman_id": "881cfd53-70bb-5e5c-b6d4-e2d43872ae97",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1382,13 +1382,13 @@
 							}
 						}
 					],
-					"_postman_id": "4a2263fa-279b-4cc1-9596-4eafcbbf296f",
+					"_postman_id": "a26cecf0-b7d5-5c88-ab40-c16918823cf7",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1480,13 +1480,13 @@
 							}
 						}
 					],
-					"_postman_id": "471f9bdb-0aa4-4806-a065-7a31a651cce0",
+					"_postman_id": "8b5b41b7-03ae-5948-8f7a-16a73fb056c4",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1578,13 +1578,13 @@
 							}
 						}
 					],
-					"_postman_id": "d58b1137-a676-44cb-aced-e707b7402231",
+					"_postman_id": "8aa1d140-a176-5519-a237-7c661d6fdb94",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1688,13 +1688,13 @@
 							}
 						}
 					],
-					"_postman_id": "3edd4e41-6c35-4c6e-9a81-97ff1bdfddbd",
+					"_postman_id": "fa454374-88e2-517c-b5ed-84afa3f366e9",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1768,7 +1768,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "b9b7c8e6-7f8e-4ce1-beae-1545f4937c64",
+			"_postman_id": "c683995d-59f2-5c43-b650-40ce84f501f5",
 			"description": "Marketing actions, in the context of Data Governance, are actions that an Experience Platform data consumer takes, for which there is a need to check for violations of data usage policies."
 		}
 	]

--- a/apis/experience-platform/Data Access API.postman_collection.json
+++ b/apis/experience-platform/Data Access API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9815e8d7-bc57-46dc-8f28-94251de997e2",
+		"_postman_id": "31edca32-e0fc-549b-9c2d-521ffef67f7c",
 		"name": "Data Access API",
 		"description": "\nData Access facilitates the access and egress of data within Adobe Experience Platform. This includes, but not limited to, the following operations:\n  * Access and download dataset files under a batch\n  * Retrieve header information regarding files\n  * Parallel / resumable downloads using HTTP range headers\n  * Pagination support for directory listings\n  * List dataset files under a succeeded/failed batch\n  * Preview CSV and Parquet files\n\n\nRelated documentation:\n  * [Data Access technical overview](https://www.adobe.io/apis/cloudplatform/dataservices/services/allservices.html#!api-specification/markdown/narrative/technical_overview/data_access_architectural_overview/data_access_architectural_overview.md)\n  * [Query dataset data using the Data Access API](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/data_access_tutorial/data_access_tutorial.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Data Access API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Data%20Access%20Service%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/export\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/export/batches/{batchId}/files\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "dd8c8d7f-7cef-460a-ab1b-38a057c0f569",
+					"_postman_id": "3fad1dce-1d65-5b3b-966b-0d04a3f43bd8",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -141,13 +141,13 @@
 							}
 						}
 					],
-					"_postman_id": "36209821-a793-4bfd-8f42-2535b65e0f67",
+					"_postman_id": "dc6718c1-25df-5da2-8845-b3b6feaedf30",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -224,7 +224,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "9b55b085-ece5-45c2-9e4b-b7e24a758f57",
+			"_postman_id": "872c2c66-0d9f-54a4-b4e9-b68a1f3d1a80",
 			"description": "Configure data access and egress for Experience Platform."
 		},
 		{
@@ -257,13 +257,13 @@
 							}
 						}
 					],
-					"_postman_id": "f1ada5b8-783f-4bce-aef5-0a3508ca8a53",
+					"_postman_id": "10693311-0850-5fd2-8357-4cd9fa807990",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json, application/octet-stream"
 							},
 							{
 								"key": "Authorization",
@@ -372,7 +372,7 @@
 							}
 						}
 					],
-					"_postman_id": "bd57273b-50d8-4ea2-8dd6-05411406a536",
+					"_postman_id": "956b1e44-49bf-5c7a-856d-2c5ab9dadba2",
 					"request": {
 						"method": "HEAD",
 						"header": [
@@ -442,7 +442,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "4395a3ca-95b4-4851-98a7-233422fbe101",
+			"_postman_id": "c2e18d6e-eb19-54a0-a7fe-99b1d31ead91",
 			"description": "Retrieve headers containing metadata for a file specified by ID."
 		},
 		{
@@ -475,13 +475,13 @@
 							}
 						}
 					],
-					"_postman_id": "e66b7dc4-c4b3-430f-9e8c-ab7292517587",
+					"_postman_id": "8e28133f-2dca-5e15-8c40-328c0a9060f4",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -544,7 +544,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "403b38d7-cc12-4b0c-8f98-2c7d79d212b3",
+			"_postman_id": "10f52a20-9fb8-562e-a789-c89b8eb0a107",
 			"description": "Retrieve the first 100 rows of CSV or Parquet files."
 		}
 	]

--- a/apis/experience-platform/Data Ingestion API.postman_collection.json
+++ b/apis/experience-platform/Data Ingestion API.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "2a6578e7-da95-4c9b-ab3e-eea7b55721d6",
+		"_postman_id": "75308ab5-5b3f-5c96-87a1-bea00b6d95a1",
 		"name": "Data Ingestion API",
-		"description": "Data Ingestion allows you to bring your data into Adobe Experience Platform through batch ingestion and streaming ingestion. Batch ingestion lets you import data in batch, from any number of datasources. Streaming ingestion lets users send data to Platform in real time from client and server-side devices.\n\nRelated documentation:\n  * [Batch ingestion overview](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/ingest_architectural_overview/ingest_architectural_overview.md)\n  * [Batch ingestion developer guide](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/ingest_architectural_overview/batch_data_ingestion_developer_guide.md)\n  * [Streaming ingestion overview](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/streaming_ingest/streaming_ingest_overview.md)\n  * [Getting started with streaming ingestion APIs](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/streaming_ingest/getting_started_with_platform_streaming_ingestion.md)\n  * [Create and populate a dataset using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/creating_a_dataset_tutorial/creating_a_dataset_tutorial.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Data Ingestion Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Data%20Ingestion%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\n\nAPI paths:\n  * Base path for batch ingestion APIs: https://<span>platform.adobe.io/data/foundation/import\n  * Base path for streaming ingestion APIs:\n    * Data inlet management: https://<span>platform.adobe.io/data/core/edge\n    * Data collection: https://<span>dcs.adobedc.net/\n  * Example of a complete path for batch ingestion: https://<span>platform.adobe.io/data/foundation/import/batches\n \nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
+		"description": "Data Ingestion allows you to bring your data into Adobe Experience Platform through batch ingestion and streaming ingestion. Batch ingestion lets you import data in batch, from any number of datasources. Streaming ingestion lets users send data to Platform in real time from client and server-side devices.\n\nRelated documentation:\n  * [Batch ingestion overview](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/ingest_architectural_overview/ingest_architectural_overview.md)\n  * [Batch ingestion developer guide](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/ingest_architectural_overview/batch_data_ingestion_developer_guide.md)\n  * [Streaming ingestion overview](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/streaming_ingest/streaming_ingest_overview.md)\n  * [Getting started with streaming ingestion APIs](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/streaming_ingest/creating_a_streaming_connection.md)\n  * [Create and populate a dataset using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/creating_a_dataset_tutorial/creating_a_dataset_tutorial.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Data Ingestion Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Data%20Ingestion%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\n\nAPI paths:\n  * Base path for batch ingestion APIs: https://<span>platform.adobe.io/data/foundation/import\n  * Base path for streaming ingestion APIs:\n    * Data inlet management: https://<span>platform.adobe.io/data/core/edge\n    * Data collection: https://<span>dcs.adobedc.net/\n  * Example of a complete path for batch ingestion: https://<span>platform.adobe.io/data/foundation/import/batches\n \nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * Requests with a payload in the request body (such as POST, PUT, and PATCH calls) may require the header `Content-Type`. Accepted values specific to each call are provided in the call parameters.  ",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "088a2582-c8e9-4f8b-bc59-413b0edff5ce",
+					"_postman_id": "802cf804-ae25-5f38-b4b5-d091e73bef6a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -159,13 +159,13 @@
 							}
 						}
 					],
-					"_postman_id": "5aeebb04-c1de-4327-8abe-0d084096022a",
+					"_postman_id": "da354586-7e94-5812-8838-a99fc4e6aa5a",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -256,13 +256,13 @@
 							}
 						}
 					],
-					"_postman_id": "85a81e72-d2ae-4c88-b20c-13656925360d",
+					"_postman_id": "fca77ff1-d0ca-5374-bc8a-18cb42f39d39",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -360,13 +360,13 @@
 							}
 						}
 					],
-					"_postman_id": "e8e0e92a-46cb-43b1-97fc-ca19d2219aec",
+					"_postman_id": "f3230f50-275c-56cb-9754-61dc84913a11",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -464,13 +464,13 @@
 							}
 						}
 					],
-					"_postman_id": "0e144a28-ad2c-48bb-b92d-b8a8b7f54b69",
+					"_postman_id": "c6b04234-c239-5766-a07d-99dfe3210fe6",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -542,7 +542,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "9f8645b9-2f41-4306-9019-a00111d41553",
+			"_postman_id": "6c5d69b3-8503-5940-aee2-fc2af659733d",
 			"description": "Data Inlets are used in conjunction with streaming API calls to ingest record and time=series data for Real-time Customer Profile."
 		},
 		{
@@ -575,13 +575,13 @@
 							}
 						}
 					],
-					"_postman_id": "a9ee482a-14de-4357-a851-4d4ac02fd1bc",
+					"_postman_id": "2579b279-c0e1-55c1-9877-a2e50700c2fd",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -672,13 +672,13 @@
 							}
 						}
 					],
-					"_postman_id": "4add0944-4d1e-497e-bb54-5c0ef9753e12",
+					"_postman_id": "23d06ea0-54f4-56cd-9d18-7953de7728ad",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -737,14 +737,14 @@
 					"response": []
 				}
 			],
-			"_postman_id": "fc180d82-e683-421e-9f05-d5c1e92383e9",
+			"_postman_id": "9e5706b9-c7ef-5b63-a70d-ac55b2935755",
 			"description": "Streaming ingestion allows you to send data from client and server-side devices to Experience Platform in real-time. It drives Real-time Customer Profile creating personalized experiences."
 		},
 		{
 			"name": "Batch Ingestion",
 			"item": [
 				{
-					"name": "Register a new batch in Adobe Data Catalog.",
+					"name": "Register a new batch in Catalog Service.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -770,13 +770,13 @@
 							}
 						}
 					],
-					"_postman_id": "c4c4e6ea-ee98-4fa9-85fb-fd218cce579d",
+					"_postman_id": "65c249c5-b7c8-5e4a-a1a0-7a4287f350de",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -830,7 +830,7 @@
 								"batches"
 							]
 						},
-						"description": "Creates a new batch in Data Catalog as a first step to bulk data ingestion. The data is uploaded to this batch after which the batch is marked ready for triggering data registration in Catalog"
+						"description": "Creates a new batch in Catalog Service as a first step to bulk data ingestion. The data is uploaded to this batch after which the batch is marked ready for triggering data registration in Catalog"
 					},
 					"response": []
 				},
@@ -861,17 +861,17 @@
 							}
 						}
 					],
-					"_postman_id": "a4f0d08a-8790-4778-bb7f-f36c4491aa09",
+					"_postman_id": "690c4c44-c12f-58ce-9107-396a399f0cfc",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/octet-stream"
 							},
 							{
 								"key": "Authorization",
@@ -971,17 +971,17 @@
 							}
 						}
 					],
-					"_postman_id": "165f313f-ff0e-4ef1-bb3d-534c95a9ec06",
+					"_postman_id": "d0fcf3f9-e07a-58f0-9845-1004718446b7",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "multipart/form-data"
 							},
 							{
 								"key": "Authorization",
@@ -1087,17 +1087,17 @@
 							}
 						}
 					],
-					"_postman_id": "395b990c-a4ba-4cd8-85fd-94a00e13eae2",
+					"_postman_id": "2eed79c3-4915-578c-b200-480ed90caabd",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "multipart/form-data"
 							},
 							{
 								"key": "Authorization",
@@ -1211,13 +1211,13 @@
 							}
 						}
 					],
-					"_postman_id": "ff0db8b1-634a-41ec-b9f0-275b41efb2e6",
+					"_postman_id": "4a81b96c-849b-5e66-b96f-86dea0e09de8",
 					"request": {
 						"method": "HEAD",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1321,13 +1321,13 @@
 							}
 						}
 					],
-					"_postman_id": "8ec3375c-5413-4cb3-bf10-fac4e2aa8c6e",
+					"_postman_id": "a6849435-c69c-5db2-a95a-8cabfdd4caaa",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1456,13 +1456,13 @@
 							}
 						}
 					],
-					"_postman_id": "7bcf32e3-8205-4827-821e-3afbcaf9dcd7",
+					"_postman_id": "6cd32898-9b6c-5bf1-872a-4897933dcb3a",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1534,7 +1534,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "6eafd985-d4ac-4570-9cfe-b89158164b92",
+			"_postman_id": "8d6002f6-2c2b-534b-ad0b-a513afd4b725",
 			"description": "Batch ingestion is used to ingest data into Experience Platform as batch files. For example, data being ingested can be the profile data from a flat file in a CRM sytem (for example: parquet, or JSON) or data that conforms to a known Experience Data Model (XDM) schema within the Schema Registry."
 		}
 	]

--- a/apis/experience-platform/Identity Service.postman_collection.json
+++ b/apis/experience-platform/Identity Service.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "698dc4cb-1368-49b8-a4e7-1b5e78168b01",
+		"_postman_id": "1897c4f2-e25d-5850-9887-c65bd2d8394c",
 		"name": "Identity Service",
-		"description": "Delivering relevant digital experiences requires having a complete understanding of your customer. This is made more difficult when your customer data is fragmented across disparate systems, causing each individual customer to appear to have multiple \"identities\". Adobe Experience Platform Identity Service provides a RESTful API to help you to gain a better view of your customers and their behavior. By bridging identities across devices and systems, you are better able to deliver impactful, personal digital experiences in real-time.\n\nRelated documentation:\n  * [Identity Service overview](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_architectural_overview.md)\n  * [Identity Service developer guide](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_api.md)\n  * [Identity namespace overview](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_namespace_overview/identity_namespace_overview.md)\n  * [Identity Service troubleshooting guide](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_faq.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Identity Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Identity%20Service.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform-{REGION}.adobe.io\n    * Information on <code>{REGION}</code> values can be found in the [Identity Service developer guide](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_api.md).\n  * Base path for this API: /data/core/\n  * Example of a complete path: https://<span>platform-va7.adobe.io/data/core/identity/cluster/members\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
+		"description": "Delivering relevant digital experiences requires having a complete understanding of your customer. This is made more difficult when your customer data is fragmented across disparate systems, causing each individual customer to appear to have multiple \"identities\". Adobe Experience Platform Identity Service provides a RESTful API to help you to gain a better view of your customers and their behavior. By bridging identities across devices and systems, you are better able to deliver impactful, personal digital experiences in real-time.\n\nRelated documentation:\n  * [Identity Service overview](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_architectural_overview.md)\n  * [Identity Service developer guide](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_api.md)\n  * [Identity namespace overview](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_namespace_overview/identity_namespace_overview.md)\n  * [Identity Service troubleshooting guide](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_faq.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Identity Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Identity%20Service.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform-{REGION}.adobe.io\n    * Information on <code>{REGION}</code> values can be found in the [Identity Service developer guide](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/identity_services_architectural_overview/identity_services_api.md).\n  * Base path for this API: /data/core/\n  * Example of a complete path: https://<span>platform-va7.adobe.io/data/core/identity/cluster/members\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -10,7 +10,7 @@
 			"name": "Identity",
 			"item": [
 				{
-					"name": "Given an id and namespace returns an identity string",
+					"name": "Given an ID and a namespace, returns an identity string.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "e12a38be-c0e7-4a08-bca8-77c4db3ced58",
+					"_postman_id": "19e8946c-1c85-5ceb-9e6f-a9d853bae323",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -61,14 +61,7 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
-								"type": "string",
-								"enabled": true
-							},
-							{
-								"key": "x-sandbox-name",
-								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
@@ -76,6 +69,13 @@
 								"key": "x-uis-cst-ctx",
 								"value": "stub",
 								"description": "Customer context to be used for stub response",
+								"type": "string",
+								"enabled": true
+							},
+							{
+								"key": "x-sandbox-name",
+								"value": "{{SANDBOX_NAME}}",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -113,12 +113,12 @@
 								}
 							]
 						},
-						"description": "Given the namespace and id in that namespace, returns XID string."
+						"description": "Given the namespace and an ID in that namespace, returns XID string."
 					},
 					"response": []
 				}
 			],
-			"_postman_id": "c8160060-4cf6-4d01-9801-cd1e33f70338",
+			"_postman_id": "460885b1-89a3-5a63-bf0b-d20680293b9c",
 			"description": "Identity services provide access to a profile identity in XID form."
 		},
 		{
@@ -151,13 +151,13 @@
 							}
 						}
 					],
-					"_postman_id": "1bca98e2-d0a7-4c6f-9db5-93dc1bc3ae03",
+					"_postman_id": "4a1659ab-e82c-5f90-aa05-6c2332894a5b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -176,14 +176,7 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
-								"type": "string",
-								"enabled": true
-							},
-							{
-								"key": "x-sandbox-name",
-								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
@@ -191,6 +184,13 @@
 								"key": "x-uis-cst-ctx",
 								"value": "stub",
 								"description": "Customer context to be used for stub response",
+								"type": "string",
+								"enabled": true
+							},
+							{
+								"key": "x-sandbox-name",
+								"value": "{{SANDBOX_NAME}}",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -268,13 +268,13 @@
 							}
 						}
 					],
-					"_postman_id": "ffaaf05e-e75a-47ef-929c-86ef81fd0c18",
+					"_postman_id": "4bd1c58f-7d56-52bb-9c09-059d1e8c1f14",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -297,14 +297,7 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
-								"type": "string",
-								"enabled": true
-							},
-							{
-								"key": "x-sandbox-name",
-								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
@@ -312,6 +305,13 @@
 								"key": "x-uis-cst-ctx",
 								"value": "stub",
 								"description": "Customer context to be used for stub response",
+								"type": "string",
+								"enabled": true
+							},
+							{
+								"key": "x-sandbox-name",
+								"value": "{{SANDBOX_NAME}}",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -366,13 +366,13 @@
 							}
 						}
 					],
-					"_postman_id": "8385326a-dd20-453b-a645-44f8424fbb8c",
+					"_postman_id": "8b97fe38-1074-5eec-b7b2-82820c0fc92a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -391,14 +391,7 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
-								"type": "string",
-								"enabled": true
-							},
-							{
-								"key": "x-sandbox-name",
-								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
@@ -406,6 +399,13 @@
 								"key": "x-uis-cst-ctx",
 								"value": "stub",
 								"description": "Customer context to be used for stub response",
+								"type": "string",
+								"enabled": true
+							},
+							{
+								"key": "x-sandbox-name",
+								"value": "{{SANDBOX_NAME}}",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -483,13 +483,13 @@
 							}
 						}
 					],
-					"_postman_id": "63a72710-9a58-42d9-9857-ddc3554f5d5b",
+					"_postman_id": "6923f5ba-f3e0-599c-aeaf-8c1c8c415fda",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -512,14 +512,7 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
-								"type": "string",
-								"enabled": true
-							},
-							{
-								"key": "x-sandbox-name",
-								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
@@ -527,6 +520,13 @@
 								"key": "x-uis-cst-ctx",
 								"value": "stub",
 								"description": "Customer context to be used for stub response",
+								"type": "string",
+								"enabled": true
+							},
+							{
+								"key": "x-sandbox-name",
+								"value": "{{SANDBOX_NAME}}",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -555,7 +555,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "eed501a9-e068-4106-b2a3-85801ce75364",
+			"_postman_id": "ce3fbe6c-bdaa-5a3d-b1f0-d01461b1f1bc",
 			"description": "Cluster services provide access to groupings of identities as linked in the identity graph."
 		},
 		{
@@ -588,13 +588,13 @@
 							}
 						}
 					],
-					"_postman_id": "111cdeab-3413-4744-a7bd-416081401396",
+					"_postman_id": "addaff6f-8e10-56b3-b9fa-1e66e8216759",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -613,14 +613,7 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
-								"type": "string",
-								"enabled": true
-							},
-							{
-								"key": "x-sandbox-name",
-								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
@@ -628,6 +621,13 @@
 								"key": "x-uis-cst-ctx",
 								"value": "stub",
 								"description": "Customer context to be used for stub response",
+								"type": "string",
+								"enabled": true
+							},
+							{
+								"key": "x-sandbox-name",
+								"value": "{{SANDBOX_NAME}}",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -704,13 +704,13 @@
 							}
 						}
 					],
-					"_postman_id": "33b30fa9-a0cb-4002-bea4-919c34d1a9a6",
+					"_postman_id": "a9ce1e0d-b623-5280-a2e5-b5243e0dcd2d",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -729,14 +729,7 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
-								"type": "string",
-								"enabled": true
-							},
-							{
-								"key": "x-sandbox-name",
-								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
@@ -744,6 +737,13 @@
 								"key": "x-uis-cst-ctx",
 								"value": "stub",
 								"description": "Customer context to be used for stub response",
+								"type": "string",
+								"enabled": true
+							},
+							{
+								"key": "x-sandbox-name",
+								"value": "{{SANDBOX_NAME}}",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -772,14 +772,14 @@
 					"response": []
 				}
 			],
-			"_postman_id": "3c2a4456-6ea7-4bea-a6a8-b976f285d7c4",
+			"_postman_id": "76a1db3d-03f9-5049-92a5-d9ba9b369a53",
 			"description": "Mapping allows you to provide a fully qualified identity and will return the linked identity from another namespace."
 		},
 		{
 			"name": "Identity Namespace",
 			"item": [
 				{
-					"name": "Lists all namespaces available to the client `x-gw-ims-org-id`",
+					"name": "Lists all identity namespaces available for the IMS Organization.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -805,13 +805,13 @@
 							}
 						}
 					],
-					"_postman_id": "ab0e5611-e77f-456d-a694-b229af975f49",
+					"_postman_id": "61fe593e-ae7a-5e88-9137-b4eb23df8c77",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -830,14 +830,14 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
 							{
 								"key": "x-sandbox-name",
 								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -865,7 +865,7 @@
 					"response": []
 				},
 				{
-					"name": "Create namespace under `x-gw-ims-org-id` IMS Org .",
+					"name": "Create a new identity namespace.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -891,13 +891,13 @@
 							}
 						}
 					],
-					"_postman_id": "1bda3dd5-d448-484d-8eeb-f7e65cab37f3",
+					"_postman_id": "809c7070-89b5-5e2d-94de-ca573e344366",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -920,21 +920,21 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
 							{
 								"key": "x-sandbox-name",
 								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{{namespace_to_create}}"
+							"raw": "{{body}}"
 						},
 						"url": {
 							"raw": "https://platform.adobe.io/data/core/idnamespace/identities",
@@ -955,7 +955,7 @@
 					"response": []
 				},
 				{
-					"name": "List details of a single namespace identified by `{id}` if it is accessible to `x-gw-ims-org-id`",
+					"name": "List details of a specific identity namespace by its ID.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -981,13 +981,13 @@
 							}
 						}
 					],
-					"_postman_id": "14800d09-c3d6-43f3-93bd-1aaa243a8bad",
+					"_postman_id": "e71c653c-67e3-5a99-9c2d-85c892704d89",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1006,14 +1006,14 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
 							{
 								"key": "x-sandbox-name",
 								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -1023,7 +1023,7 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https://platform.adobe.io/data/core/idnamespace/identities/:id",
+							"raw": "https://platform.adobe.io/data/core/idnamespace/identities/:ID",
 							"protocol": "https",
 							"host": [
 								"platform",
@@ -1035,12 +1035,12 @@
 								"core",
 								"idnamespace",
 								"identities",
-								":id"
+								":ID"
 							],
 							"variable": [
 								{
-									"value": "{{id}}",
-									"id": "id"
+									"value": "{{ID}}",
+									"id": "ID"
 								}
 							]
 						}
@@ -1048,7 +1048,7 @@
 					"response": []
 				},
 				{
-					"name": "Update namespace owned by `x-gw-ims-org-id` and having the given `id`.",
+					"name": "Update specific identity namespace by its ID.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -1074,13 +1074,13 @@
 							}
 						}
 					],
-					"_postman_id": "1e585609-7fa6-4476-9309-417697d93788",
+					"_postman_id": "96562585-eed8-558c-8010-eea7bae16048",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1103,24 +1103,24 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
 							{
 								"key": "x-sandbox-name",
 								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{{namespace_to_create}}"
+							"raw": "{{body}}"
 						},
 						"url": {
-							"raw": "https://platform.adobe.io/data/core/idnamespace/identities/:id",
+							"raw": "https://platform.adobe.io/data/core/idnamespace/identities/:ID",
 							"protocol": "https",
 							"host": [
 								"platform",
@@ -1132,12 +1132,12 @@
 								"core",
 								"idnamespace",
 								"identities",
-								":id"
+								":ID"
 							],
 							"variable": [
 								{
-									"value": "{{id}}",
-									"id": "id"
+									"value": "{{ID}}",
+									"id": "ID"
 								}
 							]
 						}
@@ -1145,7 +1145,7 @@
 					"response": []
 				},
 				{
-					"name": "Lists shared namespaces for the given `{imsorg}` or all owned if `{imsorg}` == `x-gw-ims-org-id`",
+					"name": "Lists namespaces shared by the {IMS_ORG}, or all owned namespaces if the IMS Org sent in the path matches the IMS Org sent in the header.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -1171,13 +1171,13 @@
 							}
 						}
 					],
-					"_postman_id": "9a4863f3-a5c0-4a69-9766-b9b1eca71d45",
+					"_postman_id": "31b5315b-c618-5d64-b2e2-424106823953",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1196,14 +1196,14 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
 							{
 								"key": "x-sandbox-name",
 								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -1213,7 +1213,7 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https://platform.adobe.io/data/core/idnamespace/orgs/:imsorg/identities",
+							"raw": "https://platform.adobe.io/data/core/idnamespace/orgs/:IMS_ORG/identities",
 							"protocol": "https",
 							"host": [
 								"platform",
@@ -1225,13 +1225,13 @@
 								"core",
 								"idnamespace",
 								"orgs",
-								":imsorg",
+								":IMS_ORG",
 								"identities"
 							],
 							"variable": [
 								{
-									"value": "{{imsorg}}",
-									"id": "imsorg"
+									"value": "{{IMS_ORG}}",
+									"id": "IMS_ORG"
 								}
 							]
 						}
@@ -1239,7 +1239,7 @@
 					"response": []
 				},
 				{
-					"name": "List details of a single namespace identified by `{id}` if it is accessible to `x-gw-ims-org-id`",
+					"name": "List details of a specific identity namespace owned by the {IMS_ORG} if the ID provided is accessible by the IMS Org sent in the header.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -1265,13 +1265,13 @@
 							}
 						}
 					],
-					"_postman_id": "d0f676a0-5780-4872-b51a-e29f5a16dbfb",
+					"_postman_id": "d328792a-4ae2-5dee-8d49-e84b2784058a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1290,14 +1290,14 @@
 							{
 								"key": "x-gw-ims-org-id",
 								"value": "{{IMS_ORG}}",
-								"description": "The Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
+								"description": "The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how  to obtain this value, visit the documentation covering making API calls in the  [Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/overview.html).",
 								"type": "string",
 								"enabled": true
 							},
 							{
 								"key": "x-sandbox-name",
 								"value": "{{SANDBOX_NAME}}",
-								"description": "The name of the sandbox in which the operation will take place. See the [sandboxes overview documentation](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.",
+								"description": "Identifies the Adobe Experience Platform sandbox to use. Default sandbox is 'prod'",
 								"type": "string",
 								"enabled": true
 							}
@@ -1307,7 +1307,7 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https://platform.adobe.io/data/core/idnamespace/orgs/:imsorg/identities/:id",
+							"raw": "https://platform.adobe.io/data/core/idnamespace/orgs/:IMS_ORG/identities/:ID",
 							"protocol": "https",
 							"host": [
 								"platform",
@@ -1319,18 +1319,18 @@
 								"core",
 								"idnamespace",
 								"orgs",
-								":imsorg",
+								":IMS_ORG",
 								"identities",
-								":id"
+								":ID"
 							],
 							"variable": [
 								{
-									"value": "{{imsorg}}",
-									"id": "imsorg"
+									"value": "{{IMS_ORG}}",
+									"id": "IMS_ORG"
 								},
 								{
-									"value": "{{id}}",
-									"id": "id"
+									"value": "{{ID}}",
+									"id": "ID"
 								}
 							]
 						}
@@ -1338,8 +1338,8 @@
 					"response": []
 				}
 			],
-			"_postman_id": "f390c14d-e13a-4443-af76-32e3e735d2b0",
-			"description": "Identity Namespace services allow you to work with Namespaces for your organization, such as to list all Namespaces available or to create a custom Namespace."
+			"_postman_id": "77a99e8a-8cf8-56b1-be60-53ee74773f24",
+			"description": "Identity namespaces provide context to identity data. Experience Platform provides standard namespaces as well as allowing organizations to create and manage custom namespaces."
 		}
 	]
 }

--- a/apis/experience-platform/Mapping Service API Resource.postman_collection.json
+++ b/apis/experience-platform/Mapping Service API Resource.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "3691258f-1c31-489a-86b1-fb17a3e15442",
+		"_postman_id": "a8651004-47bc-5b92-a309-e1d2c13496a8",
 		"name": "Mapping Service API Resource",
-		"description": "Mapping Service allows data to land in CSV or other simpler formats and map this data to existing Experience Data Model (XDM) schemas before landing in Adobe Experience Platform.\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Mapping Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Mapping%20Service%20API%20Resource.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/connectors\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/connectors/xdmBatchConversions\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
+		"description": "Mapping Service allows data to land in CSV or other simpler formats and map this data to existing Experience Data Model (XDM) schemas before landing in Adobe Experience Platform.\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Mapping Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Mapping%20Service%20API%20Resource.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/conversion\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/conversion/xdmBatchConversions\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "9b565c0d-9c10-4985-893c-63496d12ee86",
+					"_postman_id": "f15059c1-73d5-5b7c-a99d-ad62f1f8322d",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -78,17 +78,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets?limit=10&name={{name}}&orderBy=lastUpdateDate&property={{property}}&start=0",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets?limit=10&name={{name}}&orderBy=lastUpdateDate&property={{property}}&start=0",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets"
 							],
 							"query": [
@@ -145,13 +145,13 @@
 							}
 						}
 					],
-					"_postman_id": "ca6b16df-257d-4b89-9f7e-71fecb78e859",
+					"_postman_id": "282ac2c3-0831-54ed-9aeb-45c5a4a82ef3",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -191,17 +191,17 @@
 							"raw": "{{mappingSet}}"
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets?validate={{validate}}",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets?validate={{validate}}",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets"
 							],
 							"query": [
@@ -242,13 +242,13 @@
 							}
 						}
 					],
-					"_postman_id": "fb5c666a-f17e-402c-a500-b72e2a603545",
+					"_postman_id": "2817faf3-383b-5fc8-82d8-e0a75676eb15",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -284,17 +284,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/suggestion?batchId={{batchId}}&datasetId={{datasetId}}&excludeUnmapped=true",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/suggestion?batchId={{batchId}}&datasetId={{datasetId}}&excludeUnmapped=true",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								"suggestion"
 							],
@@ -344,13 +344,13 @@
 							}
 						}
 					],
-					"_postman_id": "e1e77b41-fcfd-4d84-9bbc-55ff8f31134d",
+					"_postman_id": "d9dd30e6-60fb-5507-8ced-0b2d98988eb4",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -386,17 +386,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:id",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:id",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":id"
 							],
@@ -438,13 +438,13 @@
 							}
 						}
 					],
-					"_postman_id": "b3ffacb1-2f7a-4e31-b466-93706c0616b6",
+					"_postman_id": "1be1b228-9209-5874-b2ae-6442e8c48f1d",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -484,17 +484,17 @@
 							"raw": "{{dms}}"
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:id",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:id",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":id"
 							],
@@ -536,13 +536,13 @@
 							}
 						}
 					],
-					"_postman_id": "030dcbeb-87e0-475d-b776-0278943509f5",
+					"_postman_id": "45d444ba-88a9-5c78-ab6d-6917abc9bc62",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -578,17 +578,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:id",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:id",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":id"
 							],
@@ -630,13 +630,13 @@
 							}
 						}
 					],
-					"_postman_id": "300f4170-c5b6-4f52-89ba-57ad81dca5a6",
+					"_postman_id": "3ec3a45e-97ff-564d-bc1a-d0f474c81e48",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -672,17 +672,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:mappingSetId/mappings",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:mappingSetId/mappings",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":mappingSetId",
 								"mappings"
@@ -725,13 +725,13 @@
 							}
 						}
 					],
-					"_postman_id": "b5bc1bda-80f8-43b6-805d-6f92461f577b",
+					"_postman_id": "4b0e8fae-cbdf-5b0c-a5b8-90f1e9fcf520",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -771,17 +771,17 @@
 							"raw": "{{mapping}}"
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:mappingSetId/mappings",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:mappingSetId/mappings",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":mappingSetId",
 								"mappings"
@@ -824,13 +824,13 @@
 							}
 						}
 					],
-					"_postman_id": "29a7637a-b44c-4f1f-a0e4-dceda53c57c3",
+					"_postman_id": "3269756d-1171-529a-b304-9c32b93b789f",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -866,17 +866,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:mappingSetId/mappings/:mappingId",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:mappingSetId/mappings/:mappingId",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":mappingSetId",
 								"mappings",
@@ -924,13 +924,13 @@
 							}
 						}
 					],
-					"_postman_id": "a949cfe8-27b2-4bfd-82fb-5508580dd61a",
+					"_postman_id": "5f540f3d-dc32-53ed-ba98-46ca02dd94c9",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -970,17 +970,17 @@
 							"raw": "{{mapping}}"
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:mappingSetId/mappings/:mappingId",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:mappingSetId/mappings/:mappingId",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":mappingSetId",
 								"mappings",
@@ -1028,13 +1028,13 @@
 							}
 						}
 					],
-					"_postman_id": "c6d95a09-7c20-496a-80e3-1ba7aa7c14c5",
+					"_postman_id": "de34c283-1576-5e02-9843-91629a5e50be",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1070,17 +1070,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/mappingSets/:mappingSetId/mappings/:mappingId",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/mappingSets/:mappingSetId/mappings/:mappingId",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"mappingSets",
 								":mappingSetId",
 								"mappings",
@@ -1102,7 +1102,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "7098115a-65ff-4034-b22e-e0f8949e3ae6",
+			"_postman_id": "2e62d5b4-ef5a-53c3-8b5f-c3a9c4d799b9",
 			"description": "Mapping Set Rest Controller"
 		},
 		{
@@ -1135,13 +1135,13 @@
 							}
 						}
 					],
-					"_postman_id": "76a345c6-67a2-48ea-b303-243f6e0e7073",
+					"_postman_id": "5a54d327-0459-5b1b-8275-da5f1aa50d0c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1177,17 +1177,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/xdmBatchConversions?destinationDatasetId={{destinationDatasetId}}&limit=10&orderBy=lastUpdateDate&property={{property}}&sourceBatchId={{sourceBatchId}}&start=0&status={{status}}",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/xdmBatchConversions?destinationDatasetId={{destinationDatasetId}}&limit=10&orderBy=lastUpdateDate&property={{property}}&sourceBatchId={{sourceBatchId}}&start=0&status={{status}}",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"xdmBatchConversions"
 							],
 							"query": [
@@ -1252,13 +1252,13 @@
 							}
 						}
 					],
-					"_postman_id": "cf17ac2e-81a6-4a4f-bd04-958602434192",
+					"_postman_id": "e8d1a00f-a5b5-548e-aa8e-e958c4926e67",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1298,17 +1298,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/xdmBatchConversions?destinationDataSetId={{destinationDataSetId}}&mappingSetId={{mappingSetId}}&sourceBatchId={{sourceBatchId}}",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/xdmBatchConversions?destinationDataSetId={{destinationDataSetId}}&mappingSetId={{mappingSetId}}&sourceBatchId={{sourceBatchId}}",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"xdmBatchConversions"
 							],
 							"query": [
@@ -1357,13 +1357,13 @@
 							}
 						}
 					],
-					"_postman_id": "e64dada0-d2e9-46c3-8f35-9613629b22da",
+					"_postman_id": "b6d82b16-f416-5477-b3da-5464605e3926",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1399,17 +1399,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/xdmBatchConversions/:id",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/xdmBatchConversions/:id",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"xdmBatchConversions",
 								":id"
 							],
@@ -1451,13 +1451,13 @@
 							}
 						}
 					],
-					"_postman_id": "d2b6e9a9-ed4a-45e6-8949-f6501fc070a4",
+					"_postman_id": "2bc67ec4-77e5-5b13-8a70-99701ee54e21",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1493,17 +1493,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/xdmBatchConversions/:id/activities",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/xdmBatchConversions/:id/activities",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"xdmBatchConversions",
 								":id",
 								"activities"
@@ -1546,13 +1546,13 @@
 							}
 						}
 					],
-					"_postman_id": "e1b74b36-ca25-42a2-a818-60a4e5cffa2d",
+					"_postman_id": "3bf3bab5-901e-5f3b-9e3c-48af34f00bc7",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1588,17 +1588,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/xdmBatchConversions/:requestId/activities/:activityId",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/xdmBatchConversions/:requestId/activities/:activityId",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"xdmBatchConversions",
 								":requestId",
 								"activities",
@@ -1646,13 +1646,13 @@
 							}
 						}
 					],
-					"_postman_id": "5a6e48b3-735b-4cca-8a59-c06143971fd6",
+					"_postman_id": "15f7c246-823f-5903-acfb-42eb11b57003",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1688,17 +1688,17 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/connectors/xdmBatchConversions/:requestId/completion?status={{status}}",
+							"raw": "https://platform.adobe.io/data/foundation/conversion/xdmBatchConversions/:requestId/completion?status={{status}}",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
-								"connectors",
+								"conversion",
 								"xdmBatchConversions",
 								":requestId",
 								"completion"
@@ -1720,7 +1720,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "f7c25951-11a1-4039-b85f-1070aa620a0a",
+			"_postman_id": "6db4c6c9-f940-5431-8298-d6ba735d84ef",
 			"description": "Data Conversion Rest Controller"
 		}
 	]

--- a/apis/experience-platform/Observability Insights.postman_collection.json
+++ b/apis/experience-platform/Observability Insights.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4d70c2ae-f04d-4d1c-9dea-56e16e0cc0aa",
+		"_postman_id": "a9c17bed-cffb-56b3-90b9-1f64fe149836",
 		"name": "Observability Insights",
 		"description": "The Observability Insights Service is used to collect and expose metrics data from various components of Observability. It listens to events broadcasting on the data pipeline and collects metrics on resources and statistics on data ingestion.\n\nRelated documentation:\n  * [Observability Insights developer guide](https://www.adobe.io/apis/experienceplatform/home/services/observability.html)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Observability Insights Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Observability%20Insights.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/infrastructure/observability/insights\n  * Example of a complete path: https://<span>platform.adobe.io/data/infrastructure/observability/insights/metrics\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "05606a94-1252-42a8-a612-5d311d16c040",
+					"_postman_id": "20a5802a-86c9-59da-af22-275874e7f28b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json, application/problem+json"
 							},
 							{
 								"key": "Authorization",
@@ -111,7 +111,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "64c6baa0-b5f6-4f99-b241-abf1c7539e20",
+			"_postman_id": "189d9835-4dba-5ce2-8fe7-e123a44f2428",
 			"description": "Observability metrics are parameters used to gain statistical insights into actions being performed in Adobe Experience Platform. These insights include counts of available Platform resources and statistics on data ingestion."
 		}
 	]

--- a/apis/experience-platform/Offer Decision Service API.postman_collection.json
+++ b/apis/experience-platform/Offer Decision Service API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "03ae4ed6-ad15-48c1-89f3-3076009de369",
+		"_postman_id": "85b3a546-2fce-5a16-a9d8-ed09ee984843",
 		"name": "Offer Decision Service API",
 		"description": "Adobe Experience Platform Decisioning Service provides the ability to programmatically and intelligently select the ‘Next Best Experience’ from a set of available options for a given individual, deliver them to any channel or application, and perform reporting and analysis on those experiences. The Offer Decision Service API includes an endpoint to filter out offers which are not approved, do not match the offer filter, or don’t have a representation for the placement referenced by the activity. It also allows you to run diagnostics and return a timestamp indicating when the offer catalog and/or activities were last updated, and a list of errors that occurred when doing so.\n\nRelated documentation:\n  * [Decisioning Service overview](https://www.adobe.io/apis/experienceplatform/home/services/decisioning-service.html#!api-specification/markdown/narrative/technical_overview/decisioning-overview/decisioning-service-overview.md)\n  * [Work with Decisioning Service runtime using APIs tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/decisioning_tutorial/decisioning_runtime_api_tutorial.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Offer Decision Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Offer%20Decision%20Service%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/core/ode\n  * Example of a complete path: https://<span>platform.adobe.io/data/core/ode/{containerId}/decisions\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "733e7390-7bc1-47ce-8509-4705a7ba0715",
+					"_postman_id": "8459e1b3-b56b-5754-9baa-beb5826bbe26",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json, application/problem+json"
 							},
 							{
 								"key": "Content-Type",
@@ -115,7 +115,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "79fe0900-59fb-48bf-815a-de9d1bea2c29",
+			"_postman_id": "48b640ea-db75-538b-b5fd-3ad4b90a20cc",
 			"description": "Determine the best offer(s) for a given set of activities based on eligibility rules that match profile and context data provided."
 		},
 		{
@@ -148,13 +148,13 @@
 							}
 						}
 					],
-					"_postman_id": "8a54ded9-537c-4290-b4b7-886de222dc32",
+					"_postman_id": "6b2025c1-5c11-5589-8d7b-5e777b231867",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.xdm+json, application/problem+json"
 							},
 							{
 								"key": "Content-Type",
@@ -227,7 +227,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "eb34c780-ac23-44c4-bc2f-f52aa0a04540",
+			"_postman_id": "583f026e-3771-5cf0-a20e-465262df5dee",
 			"description": "Return a timestamp indicating when the offer catalog and/or activities were last updated, and a list of errors that occurred when doing so."
 		},
 		{
@@ -260,13 +260,13 @@
 							}
 						}
 					],
-					"_postman_id": "ae2ee65e-cb27-424c-bd97-ff37823a136c",
+					"_postman_id": "63876e45-1d0c-579d-9a9d-27fde4a649a0",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json, application/problem+json"
 							},
 							{
 								"key": "Content-Type",
@@ -345,7 +345,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "633cef33-f01c-44b7-9c9b-12a17bbea8cd",
+			"_postman_id": "50da4868-bcc3-591a-b1c9-eaa3b5dd8d62",
 			"description": "Based on filter rules and placement match, return approved offers that belong to a specific `activityId`."
 		}
 	]

--- a/apis/experience-platform/Partner Connectors API.postman_collection.json
+++ b/apis/experience-platform/Partner Connectors API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "58f12bf9-517f-4905-bf06-10c4d905474f",
+		"_postman_id": "4ca1ff74-a372-53d4-8b36-2d5390804e0a",
 		"name": "Partner Connectors API",
 		"description": "Partner Connectors provides a RESTful API for ingesting data into Adobe Experience Platform by allowing you to connect to 3rd party storage and CRM systems.\n\nRelated documentation:\n  * [Data connectors overview](https://www.adobe.io/apis/experienceplatform/home/data-ingestion/data-ingestion-services.html#!api-specification/markdown/narrative/technical_overview/acp_connectors_overview/acp-connectors-overview.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Partner Connectors API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Partner%20Connectors%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/connectors\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/connectors/account\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "c32a7cd5-87e4-41a8-8586-516575d30817",
+					"_postman_id": "a72e88f6-964e-5b6e-b200-bf806a6c6544",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -126,13 +126,13 @@
 							}
 						}
 					],
-					"_postman_id": "3209d162-25f1-4420-a49f-1753b9968667",
+					"_postman_id": "3ab82c3b-dd7a-5dc1-b2b3-a162a949888c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -223,13 +223,13 @@
 							}
 						}
 					],
-					"_postman_id": "b342b753-8beb-4411-bedf-33f3064d62e5",
+					"_postman_id": "4cb0d5f7-0080-5809-88a6-a92a617704f7",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -294,7 +294,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "3cc9df84-796b-48d6-a966-da27403c7b94",
+			"_postman_id": "67223e59-ccdf-540b-a073-4bccaaf8ce46",
 			"description": "Authenticate your storage systems and CRM services to allow your data to be ingested from various sources (such as cloud-based storage, and CRM data) into Experience Platform."
 		},
 		{
@@ -327,13 +327,13 @@
 							}
 						}
 					],
-					"_postman_id": "a0d29552-8562-4303-ac06-c1a13a65e2b7",
+					"_postman_id": "329ede8b-e1ed-5e1e-90be-a55fef340424",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -405,7 +405,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "370704e3-2f53-4c01-b83e-76f637ee9a67",
+			"_postman_id": "424fad3c-763c-5fa0-9bb5-84dae816bb59",
 			"description": "Returns a list object files or tables at the source location."
 		},
 		{
@@ -438,13 +438,13 @@
 							}
 						}
 					],
-					"_postman_id": "6622a3f7-4f2e-45e8-ac49-1bd0775c18fc",
+					"_postman_id": "d10df7f1-bad1-5b69-b0df-eb17d8ca0e50",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -546,13 +546,13 @@
 							}
 						}
 					],
-					"_postman_id": "bbb9eb2e-22a8-434a-b85f-38262cf1920b",
+					"_postman_id": "2a824182-c8e4-56fb-a035-c4ab1cbe7ea7",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -628,7 +628,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "c735817b-1b33-42ae-9982-d254d29cd950",
+			"_postman_id": "1a3a94d0-e770-5669-a66e-a6d1c49a28a1",
 			"description": "Returns a list of schema fields or a data preview for a given object."
 		},
 		{
@@ -661,13 +661,13 @@
 							}
 						}
 					],
-					"_postman_id": "e87a33d0-2b44-464b-b821-af63bcaef9b9",
+					"_postman_id": "ff979317-7692-50a4-b411-a68fa8a13071",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -733,7 +733,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "cc8b4403-935d-4290-9668-48ec1bd6db8a",
+			"_postman_id": "67a452f5-cd8e-5402-856d-0f1a10619393",
 			"description": "Creates a dataset for a connection to ingest data into and persist within Platform."
 		},
 		{
@@ -766,13 +766,13 @@
 							}
 						}
 					],
-					"_postman_id": "fa6b70cb-adaf-4e30-83f5-fb8256256f5a",
+					"_postman_id": "3fe87a51-dea4-55cd-9af6-7ee3a15b9d67",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -838,7 +838,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "3e923d82-2bd2-4d20-8dc5-d7cf37245ca0",
+			"_postman_id": "9368c4cb-db78-5011-9a77-a0aef8257c2f",
 			"description": "Schedule ingestion from your authenticated connector into Data Lake at a given start date and frequency. Frequency can be set for every month, day, day of the week, hour, or minute."
 		},
 		{
@@ -871,13 +871,13 @@
 							}
 						}
 					],
-					"_postman_id": "c43c26aa-14f3-4eb0-a61a-68b6a9e7480b",
+					"_postman_id": "b572ba2e-acf9-5246-8bb8-531d3b172c4d",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -943,7 +943,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "60379510-672b-4ba3-92b2-3fc15446d8e6",
+			"_postman_id": "76728cd6-6629-5c9e-bca5-0d4cd69fe46c",
 			"description": "Create a custom schema by fields or objectName."
 		}
 	]

--- a/apis/experience-platform/Privacy Service API.postman_collection.json
+++ b/apis/experience-platform/Privacy Service API.postman_collection.json
@@ -1,13 +1,13 @@
 {
 	"info": {
-		"_postman_id": "6337f31c-4208-462c-a1f8-0853c3acde98",
+		"_postman_id": "81656699-1280-594e-80ff-75485f86f4a8",
 		"name": "Privacy Service API",
 		"description": "Adobe Experience Platform Privacy Service provides a common, centralized facilitation of access/delete requests and opt-out-of-sale requests for private data. The service includes a UI for selecting and creating requests, a business layer that processes incoming and outgoing traffic, a data store for audit and logging information, and temporary storage for data retrieval while requests are pending or waiting to be viewed.\n\nRelated documentation:\n  * [Privacy Service overview](https://www.adobe.io/apis/experienceplatform/home/services/privacy-service.html#!api-specification/markdown/narrative/technical_overview/privacy_service_overview/privacy_service_overview.md)\n  * [Privacy Service API tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/privacy_service_tutorial/privacy_service_api_tutorial.md)\n  * [GDPR on Adobe Experience Platform Overview](https://www.adobe.io/apis/experienceplatform/home/services/privacy-service.html#!api-specification/markdown/narrative/technical_overview/privacy_service_overview/gdpr-on-platform-overview.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Privacy Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Privacy%20Service%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/core/privacy/jobs\n  * Example of a complete path: https://<span>platform.adobe.io/data/core/privacy/jobs/ping\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "Privacy Service",
+			"name": "Privacy Jobs",
 			"item": [
 				{
 					"name": "Retrieve details of all jobs for the current logged-in user.",
@@ -36,7 +36,7 @@
 							}
 						}
 					],
-					"_postman_id": "3b33b520-32f5-423c-8c6e-ba5279c847cf",
+					"_postman_id": "6ee99d09-1dbd-5160-b76a-13056104e974",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -132,13 +132,13 @@
 							}
 						}
 					],
-					"_postman_id": "16a76f1f-6976-4430-8ade-03dbb2756884",
+					"_postman_id": "87d5b0f4-7d66-57d4-970c-8499b668ed34",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -223,7 +223,7 @@
 							}
 						}
 					],
-					"_postman_id": "bbebaa8c-1f0b-491f-8db8-de346d3e1c83",
+					"_postman_id": "52e30902-0ab3-54f9-9817-d5a86fa0bc6f",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -305,7 +305,7 @@
 							}
 						}
 					],
-					"_postman_id": "54482d51-3fe6-42f0-8f6a-dfec7cb67538",
+					"_postman_id": "4d78b1f3-5f9c-5a24-a622-4963717a9810",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -393,7 +393,7 @@
 							}
 						}
 					],
-					"_postman_id": "688bf985-e92b-4b31-a489-3a040c06f3dc",
+					"_postman_id": "67637c50-f194-5df9-9063-73329f2f6e14",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -457,7 +457,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "1acb4711-6f32-4983-8f5f-b99bfaa0b422",
+			"_postman_id": "5766e343-1a0b-5ce0-b2de-8cd6c60ea347",
 			"description": "Retrieve and create access/delete requests, including child jobs for existing requests."
 		},
 		{
@@ -490,13 +490,13 @@
 							}
 						}
 					],
-					"_postman_id": "78e9c908-6cbf-4ef4-b96c-ef1e6c00e93a",
+					"_postman_id": "cbf6aa59-ed63-5782-850e-a7b593ef4341",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -584,17 +584,17 @@
 							}
 						}
 					],
-					"_postman_id": "ed079f45-eb4b-49f6-b30e-ccad85d880b1",
+					"_postman_id": "3559cbc7-32ca-5fe3-ab91-40237345dfa9",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "multipart/form-data"
 							},
 							{
 								"key": "Authorization",
@@ -668,7 +668,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "38eacf63-2271-4a71-8212-be1d1a5677f9",
+			"_postman_id": "6d052508-186c-5749-bc7a-f1fd360a2731",
 			"description": "View and upload files from various Adobe solutions for specified job requests."
 		},
 		{
@@ -701,7 +701,7 @@
 							}
 						}
 					],
-					"_postman_id": "cfa6edb0-e6c9-4a90-b445-ab515ba7416a",
+					"_postman_id": "e718d13a-92b0-5777-984c-e9673527e6c7",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -764,7 +764,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "8ac0324d-9dfc-4363-ad64-6a9afdecf2eb",
+			"_postman_id": "b4c29a70-3a18-5f42-916b-23a5b46dfef3",
 			"description": "Check the processing status of access or delete requests by supplying a status code integer as a query parameter."
 		},
 		{
@@ -797,7 +797,7 @@
 							}
 						}
 					],
-					"_postman_id": "9266d93f-329e-40e4-b7de-8f933425081f",
+					"_postman_id": "098c0c7c-afdf-589c-91fd-e2d8ee9ae37b",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -880,7 +880,7 @@
 							}
 						}
 					],
-					"_postman_id": "92175a30-1467-4ad4-8930-10eba20a49ef",
+					"_postman_id": "a268369a-922a-5923-bd53-3087c373da1e",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -944,7 +944,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "ce6f6108-f38c-464c-99aa-9ac9dca08add",
+			"_postman_id": "ceb49ca1-46a3-5bac-8e74-5aa752cd0e8c",
 			"description": "View details of Adobe products available within your organization's Privacy Service integrations."
 		},
 		{
@@ -977,7 +977,7 @@
 							}
 						}
 					],
-					"_postman_id": "b49cd7ce-8de1-4c80-8229-1de8ac574db8",
+					"_postman_id": "8f1f8b2e-5942-593d-8b08-316666e7df2e",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -1060,7 +1060,7 @@
 							}
 						}
 					],
-					"_postman_id": "492d982f-7958-4675-84ab-bb026c80529a",
+					"_postman_id": "99167d7d-2fb4-5d1c-b465-a6575165e883",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -1143,7 +1143,7 @@
 							}
 						}
 					],
-					"_postman_id": "844efead-b6b9-422d-820d-e314392c0647",
+					"_postman_id": "9c526030-0ac0-5ae8-aa4b-c0c99c987ca8",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -1233,7 +1233,7 @@
 							}
 						}
 					],
-					"_postman_id": "2d437922-ead4-41b7-b349-df4900eaaddf",
+					"_postman_id": "cbbf84a0-a972-53ba-ad44-730eaf822350",
 					"request": {
 						"method": "PUT",
 						"header": [
@@ -1323,7 +1323,7 @@
 							}
 						}
 					],
-					"_postman_id": "b3f8aa85-2055-4fcf-90bd-7439dbd55f28",
+					"_postman_id": "925e7d6d-5b0e-5b7e-a121-2757f481fea4",
 					"request": {
 						"method": "DELETE",
 						"header": [
@@ -1387,7 +1387,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "25bb86c7-a666-4380-8ce5-8c396dd4c161",
+			"_postman_id": "e2c66040-05fc-5f8f-a8dc-2a58eea70250",
 			"description": "View, create, update, or delete users and their permissions within your organization's Privacy Service configuration."
 		}
 	]

--- a/apis/experience-platform/Query Service API.postman_collection.json
+++ b/apis/experience-platform/Query Service API.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "c2cfde4f-ee0f-4373-9640-d6e62460133a",
+		"_postman_id": "d342d9ac-ca32-5412-8cb3-ab8d735a9237",
 		"name": "Query Service API",
-		"description": "Experience Query Service gives you the ability to use standard SQL to query data on Adobe Experience Platform to support many different use cases. It is a serverless tool which allows you to join any datasets in Experience Data Lake and capture the query results as a new dataset for use in reporting, Data Science Workspace, or for ingestion into Real-time Customer Profile.\n\nRelated Documentation:\n  * [Query Service overview](https://www.adobe.io/apis/experienceplatform/home/services/query-service/query-service.html#!end-user/markdown/query-service/qs-intro.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Query Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Query%20Service%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/query\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/query/queries\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
+		"description": "Experience Query Service gives you the ability to use standard SQL to query data on Adobe Experience Platform to support many different use cases. It is a serverless tool which allows you to join any datasets in Experience Data Lake and capture the query results as a new dataset for use in reporting, Data Science Workspace, or for ingestion into Real-time Customer Profile.\n\nRelated Documentation:\n  * [Query Service overview](https://www.adobe.io/apis/experienceplatform/home/query-service/overview.html#!api-specification/markdown/narrative/technical_overview/markdown/query-service/overview/overview.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Query Service API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Query%20Service%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/query\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/query/queries\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "325416e4-44e5-4d55-9a01-8b22d1b16a78",
+					"_postman_id": "d6f31af1-73a0-50c7-b180-a6ce40211d8e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -114,7 +114,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "e2294f4d-bf83-4d32-bcda-2402c49d856a",
+			"_postman_id": "aa03891b-78d2-5298-9582-d1565082d3d1",
 			"description": "Retrieves connection parameters for the interactive interface."
 		},
 		{
@@ -147,13 +147,13 @@
 							}
 						}
 					],
-					"_postman_id": "ba663c5b-5e68-4fc4-b514-52697e446e16",
+					"_postman_id": "64fc8877-4b14-5571-937a-c97c0f78676c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -277,13 +277,13 @@
 							}
 						}
 					],
-					"_postman_id": "31a1d0e9-6659-4dfb-8e14-52c8e93ad248",
+					"_postman_id": "023b8d49-3aa8-5ee1-8d33-a7c54ec0c767",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -374,13 +374,13 @@
 							}
 						}
 					],
-					"_postman_id": "1bde054e-08c4-4cab-a07c-8729b704d131",
+					"_postman_id": "0d248db6-88e7-54d9-8255-6ce5f86a39c5",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -485,13 +485,13 @@
 							}
 						}
 					],
-					"_postman_id": "b7e3445c-ed50-4d1c-a5bf-58bbe7062971",
+					"_postman_id": "419c68b8-5a5c-55d6-a470-937560cedb1b",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -570,7 +570,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "2d74a8b6-e05b-425f-aeab-3b702855fa24",
+			"_postman_id": "016699b6-e760-570e-b606-94a768bc90b1",
 			"description": "Queries let you use standard SQL to query data in Adobe Experience Platform. For example, you can join any number of datasets in Experience Data Lake and capture the results as a new dataset."
 		},
 		{
@@ -603,13 +603,13 @@
 							}
 						}
 					],
-					"_postman_id": "96ef1de9-aa1a-40cd-b49e-4e51ec495e90",
+					"_postman_id": "d4b51682-5181-5714-a704-1b5eee773efa",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -725,13 +725,13 @@
 							}
 						}
 					],
-					"_postman_id": "e804d63c-d174-420e-908c-8be29ce306e8",
+					"_postman_id": "6056877b-7d84-5b6d-8bce-97ea21ecb2e6",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -829,13 +829,13 @@
 							}
 						}
 					],
-					"_postman_id": "d42c2766-9a89-46bc-a069-8bd92953ccbd",
+					"_postman_id": "9b6637c6-a695-5cd3-a43b-87f62de8c078",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -940,13 +940,13 @@
 							}
 						}
 					],
-					"_postman_id": "632afe00-95fb-4b0e-8aef-a64afe9d0f27",
+					"_postman_id": "877dd2ea-4879-5cf3-9f25-dc0f7359dff2",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1051,13 +1051,13 @@
 							}
 						}
 					],
-					"_postman_id": "a84abb5d-50fc-4175-b1e6-80db13bebc6b",
+					"_postman_id": "b1cfb5fa-d292-5a82-8501-cee8d7e9f227",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1162,13 +1162,13 @@
 							}
 						}
 					],
-					"_postman_id": "3ae698a5-f75c-44b4-8d12-0bf1e220364c",
+					"_postman_id": "a1e22026-82aa-598c-b925-9294cbea4a2e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1292,13 +1292,13 @@
 							}
 						}
 					],
-					"_postman_id": "4e900452-81f7-4fea-aad7-8b6acd1bc195",
+					"_postman_id": "25f7b57c-1d6a-5506-9059-0eb880b9b767",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1404,13 +1404,13 @@
 							}
 						}
 					],
-					"_postman_id": "aad93fc9-e4f9-4385-b4f5-9a457c96df9a",
+					"_postman_id": "edc349b9-c5bb-5d4b-b9b4-34a7a781e625",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1521,13 +1521,13 @@
 							}
 						}
 					],
-					"_postman_id": "24ab6ee0-5ceb-4d74-bb61-125b16b91b41",
+					"_postman_id": "f7b3d60a-d77f-537e-bcfc-3510d0f83c4d",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1612,7 +1612,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "394b8ee1-e6c7-425c-b334-63fa7fa4ae30",
+			"_postman_id": "f452f32c-8ba6-5194-83db-a633f5565785",
 			"description": "Schedules let you perform SQL functions from a start date to an end date."
 		},
 		{
@@ -1645,13 +1645,13 @@
 							}
 						}
 					],
-					"_postman_id": "11a514bd-7ff3-4b3a-b9b6-7e8b80ddf955",
+					"_postman_id": "2a4d90b8-6fff-5c65-b5f4-b789fa5e431e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1767,13 +1767,13 @@
 							}
 						}
 					],
-					"_postman_id": "1456f748-5d3e-4cbb-9dbf-c7df464b0ff8",
+					"_postman_id": "c378b39e-ccab-5a9a-ab6e-c85fb26b2b8f",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1871,13 +1871,13 @@
 							}
 						}
 					],
-					"_postman_id": "df7a3047-b550-4b10-8cac-76fa3357a59b",
+					"_postman_id": "a3f5ed0f-87d8-524b-87c4-6447a7f2ae99",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1982,13 +1982,13 @@
 							}
 						}
 					],
-					"_postman_id": "3cdc6353-d1d4-42e2-ab09-1c4211590990",
+					"_postman_id": "8953e266-75e1-5ee0-ab19-d2280568f624",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2093,13 +2093,13 @@
 							}
 						}
 					],
-					"_postman_id": "7ab95a5b-3a88-48ef-a6b2-ec5918b9d81d",
+					"_postman_id": "0fb76354-1dc2-544b-856c-73b34e53ea9d",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2178,7 +2178,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "0bed7aed-d7eb-4137-836c-fbd2ad7b3d87",
+			"_postman_id": "5f6e4805-81d6-5f53-8dde-5ee3fdf98910",
 			"description": "Query templates let you create, store and execute any of the query as adhoc or schedule service."
 		}
 	]

--- a/apis/experience-platform/Real-time Customer Profile API.postman_collection.json
+++ b/apis/experience-platform/Real-time Customer Profile API.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "133afb71-14d6-4ede-ba0b-fccbb9147eb2",
+		"_postman_id": "1688a7af-b44d-58d4-9dff-c6514c68ecb8",
 		"name": "Real-time Customer Profile API",
-		"description": "Real-time Customer Profile enables you to drive coordinated, consistent, and relevant experiences for your customers no matter where or when they interact with your brand. Profile provides a holistic view of each individual customer that combines data from multiple channels, including online, offline, CRM, and third-party data.\n\nThe Real-time Customer Profile API allows you to programmatically integrate Profile's various functionalities into your service, providing RESTful endpoints for merge policy configuration, segmentation, edge projections, and more.\n\nRelated overview documentation:\n  * [Real-time Customer Profile overview](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/unified_profile_architectural_overview/unified_profile_architectural_overview.md)\n  * [Profile Query Language (PQL)](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/unified_profile_architectural_overview/unified_profile_pql.md)\n  \nRelated tutorials:\n  * [Configure Real-time Customer Profile using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/configuring_up_tutorial/configuring_up_tutorial.md)\n  * [Access Real-time Customer Profile data using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/consuming_unified_profile_data/consuming_unified_profile_data.md)\n  * [Work with merge policies using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/configuring_up_tutorial/configuring_merge_policies_tutorial.md)\n  * [Create segments using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/creating_a_segment_tutorial/creating_a_segment_tutorial.md)\n  * [Evaluate and access segment results](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/segmentation/evaluate_segment.md)\n  * [Configure and access computed attributes](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/computed_attributes/computed-attributes-tutorial.md)\n  * [Delete a dataset or specific batch in a dataset](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/datasets/delete-dataset.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Real-time Customer Profile API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Real-time%20Customer%20Profile%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/core/ups\n  * Example of a complete path: https://<span>platform.adobe.io/data/core/ups/config/mergePolicies\n  \nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
+		"description": "Real-time Customer Profile enables you to drive coordinated, consistent, and relevant experiences for your customers no matter where or when they interact with your brand. Profile provides a holistic view of each individual customer that combines data from multiple channels, including online, offline, CRM, and third-party data.\n\nThe Real-time Customer Profile API allows you to programmatically integrate Profile's various functionalities into your service, providing RESTful endpoints for merge policy configuration, segmentation, edge projections, and more.\n\nRelated overview documentation:\n  * [Real-time Customer Profile overview](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/unified_profile_architectural_overview/unified_profile_architectural_overview.md)\n  * [Profile Query Language (PQL)](https://www.adobe.io/apis/experienceplatform/home/profile-identity-segmentation/profile-identity-segmentation-services.html#!api-specification/markdown/narrative/technical_overview/segmentation/profile_query_language.md)\n  \nRelated tutorials:\n  * [Configure Real-time Customer Profile using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/configuring_up_tutorial/configuring_up_tutorial.md)\n  * [Access Real-time Customer Profile data using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/consuming_unified_profile_data/consuming_unified_profile_data.md)\n  * [Work with merge policies using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/configuring_up_tutorial/configuring_merge_policies_tutorial.md)\n  * [Create segments using APIs](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/creating_a_segment_tutorial/creating_a_segment_tutorial.md)\n  * [Evaluate and access segment results](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/segmentation/evaluate_segment.md)\n  * [Configure and access computed attributes](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/computed_attributes/computed-attributes-tutorial.md)\n  * [Delete a dataset or specific batch in a dataset](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/datasets/delete-dataset.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Real-time Customer Profile API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Real-time%20Customer%20Profile%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/core/ups\n  * Example of a complete path: https://<span>platform.adobe.io/data/core/ups/config/mergePolicies\n  \nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type`. Accepted values specific to each call are provided in the call parameters.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "1dd6d030-8cbb-465a-a745-a03b42c68e42",
+					"_postman_id": "ab60a165-0e0a-58b0-ab9c-028180fed8b0",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -92,7 +92,8 @@
 								"config",
 								"computedAttributes"
 							]
-						}
+						},
+						"description": "**Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.**"
 					},
 					"response": []
 				},
@@ -123,13 +124,13 @@
 							}
 						}
 					],
-					"_postman_id": "8781fc46-d52a-4438-be02-c9c678af113b",
+					"_postman_id": "6a5943fe-288f-5ca5-9d52-841eea2bec14",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -180,7 +181,7 @@
 								"computedAttributes"
 							]
 						},
-						"description": "In order to configure a computed attribute, you first need to identify the field that will hold the computed attribute value. This field can be created using a mixin to add a new field to an existing schema, or by selecting a field that you have already defined within a schema.\n\n**Note:** Computed attributes cannot be added to fields within Adobe-defined mixins, the field must be within the tenant namespace ({TENANT_ID}), meaning it must be a field that you define and add to a schema.\n\nIn order to successfully define a computed attribute field, the schema must be enabled for Profile and appear as part of the union schema for the class upon which the schema is based. For more information, see the [tutorial for configuring and accessing computed attributes](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/computed_attributes/computed-attributes-tutorial.md)."
+						"description": "**Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.**  \n\nIn order to configure a computed attribute, you first need to identify the field that will hold the computed attribute value. This field can be created using a mixin to add a new field to an existing schema, or by selecting a field that you have already defined within a schema.\n\n**Note:** Computed attributes cannot be added to fields within Adobe-defined mixins, the field must be within the tenant namespace ({TENANT_ID}), meaning it must be a field that you define and add to a schema.\n\nIn order to successfully define a computed attribute field, the schema must be enabled for Profile and appear as part of the union schema for the class upon which the schema is based. For more information, see the [tutorial for configuring and accessing computed attributes](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/computed_attributes/computed-attributes-tutorial.md)."
 					},
 					"response": []
 				},
@@ -211,13 +212,13 @@
 							}
 						}
 					],
-					"_postman_id": "18274b33-8be1-491b-a31f-d8e10a63aa89",
+					"_postman_id": "22d2a4cc-1c95-5f49-9430-048c1e1e7e5b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -274,7 +275,8 @@
 									"id": "ATTRIBUTE_ID"
 								}
 							]
-						}
+						},
+						"description": "**Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.** "
 					},
 					"response": []
 				},
@@ -305,13 +307,13 @@
 							}
 						}
 					],
-					"_postman_id": "bfd9f782-b823-43c2-971e-145acd38ec1c",
+					"_postman_id": "c05d8985-4ce5-5c95-9bea-b67e80c7ae69",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -368,7 +370,8 @@
 									"id": "ATTRIBUTE_ID"
 								}
 							]
-						}
+						},
+						"description": "**Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.** "
 					},
 					"response": []
 				},
@@ -399,13 +402,13 @@
 							}
 						}
 					],
-					"_postman_id": "f24cefa1-8f4b-4fbd-b976-b89710777d7a",
+					"_postman_id": "7d55c47a-c686-553f-9849-71162e64fdde",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -462,13 +465,14 @@
 									"id": "ATTRIBUTE_ID"
 								}
 							]
-						}
+						},
+						"description": "**Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.** "
 					},
 					"response": []
 				}
 			],
-			"_postman_id": "97114167-8951-480e-8c69-6272a8967d5b",
-			"description": "Computed attributes enable a field value to be automatically computed based on other values, calculations, and expressions."
+			"_postman_id": "e09ff968-27c2-5634-9a00-65634cc92d39",
+			"description": "Computed attributes enable a field value to be automatically computed based on other values, calculations, and expressions. Computed attributes functionality is in alpha and is not available to all users. Functionality is subject to change."
 		},
 		{
 			"name": "Merge policies",
@@ -500,13 +504,13 @@
 							}
 						}
 					],
-					"_postman_id": "a2e07775-921b-4044-ae0e-c0e128e3bec2",
+					"_postman_id": "0d9d9832-c624-5611-8fe9-e6ad022ddf8b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -616,13 +620,13 @@
 							}
 						}
 					],
-					"_postman_id": "ce086fd9-bebd-4b4e-9c9a-cc61b9a045dc",
+					"_postman_id": "44a3e5e4-832e-5272-8c2c-834581c5bcc4",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -717,13 +721,13 @@
 							}
 						}
 					],
-					"_postman_id": "1ff35543-c920-4cbc-af46-b2b404f7c527",
+					"_postman_id": "900a7e0b-5869-5407-84ff-cb55ad47dd15",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -818,13 +822,13 @@
 							}
 						}
 					],
-					"_postman_id": "b102ae26-dc07-4bb2-a634-173d885170fd",
+					"_postman_id": "1e199a6b-6fc4-510e-aa87-a31846b0e1d2",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -926,13 +930,13 @@
 							}
 						}
 					],
-					"_postman_id": "5ed466d6-e2dc-4c63-a126-27621b24263e",
+					"_postman_id": "1cb5c555-c62f-5036-a69d-c0ddf14daf6e",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1034,13 +1038,13 @@
 							}
 						}
 					],
-					"_postman_id": "075cdaf3-597c-4dc0-8c0d-7b6a61f4ca24",
+					"_postman_id": "1cddf020-ba5b-5616-8d36-ef80423a880b",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1109,8 +1113,8 @@
 					"response": []
 				}
 			],
-			"_postman_id": "7eeaf099-4841-45dc-a885-b88a976f9224",
-			"description": "A merge policy is a set of configurations controlling aspects of identity stitching and data fragment merging. Merge policies are specific to a single schema, and can only be used to access entities adhering to that schema."
+			"_postman_id": "66a9381e-4518-5cd3-a0f2-ee5ba8f308dd",
+			"description": "Merge policies are the rules that Platform uses to determine how data will be prioritized and what data will be combined to create an individual customer profile."
 		},
 		{
 			"name": "Entities",
@@ -1142,13 +1146,13 @@
 							}
 						}
 					],
-					"_postman_id": "6fdc4ab2-dec7-4278-bfd1-93899528ee30",
+					"_postman_id": "71f650f1-8ac4-5ae0-93a6-e48d15fdc7c8",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1184,7 +1188,7 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https://platform.adobe.io/data/core/ups/access/entities?schema.name={{schema.name}}&relatedSchema.name={{relatedSchema.name}}&entityId={{entityId}}&entityIdNS={{entityIdNS}}&relatedEntityId={{relatedEntityId}}&relatedEntityIdNS={{relatedEntityIdNS}}&fields={{fields}}&mergePolicyId={{mergePolicyId}}&startTime={{startTime}}&endTime={{endTime}}&limit={{limit}}&orderby={{orderby}}",
+							"raw": "https://platform.adobe.io/data/core/ups/access/entities?schema.name={{schema.name}}&relatedSchema.name={{relatedSchema.name}}&entityId={{entityId}}&entityIdNS={{entityIdNS}}&relatedEntityId={{relatedEntityId}}&relatedEntityIdNS={{relatedEntityIdNS}}&fields={{fields}}&mergePolicyId={{mergePolicyId}}&startTime={{startTime}}&endTime={{endTime}}&limit={{limit}}&orderby={{orderby}}&withCA={{withCA}}",
 							"protocol": "https",
 							"host": [
 								"platform",
@@ -1246,6 +1250,10 @@
 								{
 									"key": "orderby",
 									"value": "{{orderby}}"
+								},
+								{
+									"key": "withCA",
+									"value": "{{withCA}}"
 								}
 							]
 						}
@@ -1279,13 +1287,13 @@
 							}
 						}
 					],
-					"_postman_id": "aba05959-c899-44ef-a482-0ad0fc0266cb",
+					"_postman_id": "9a36fa69-743f-53ec-8ab3-0fd4515c0f90",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1370,13 +1378,13 @@
 							}
 						}
 					],
-					"_postman_id": "ca293782-0323-4c68-b359-2a500b254fe3",
+					"_postman_id": "4d60b5bd-fef6-5dc0-a63d-79a091954748",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1449,8 +1457,8 @@
 					"response": []
 				}
 			],
-			"_postman_id": "5846fc70-36b9-49d0-b90b-b3d951d6fd26",
-			"description": "Entities are Experience Data Model (XDM) objects whose attributes, data contents, and related time-series events have been merged from various sources by Real-time Customer Profile."
+			"_postman_id": "fcfe333d-f747-595f-a4ef-04adb04fc40c",
+			"description": "An entity is an Experience Data Model (XDM) object whose attributes and related time-series events have been merged from various sources to form an individual profile."
 		},
 		{
 			"name": "Export jobs",
@@ -1482,13 +1490,13 @@
 							}
 						}
 					],
-					"_postman_id": "327eb382-8ecd-436b-bbaf-e2469aa8c0bb",
+					"_postman_id": "f1901b29-8bd0-5e73-a466-7170369f56ad",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1583,13 +1591,13 @@
 							}
 						}
 					],
-					"_postman_id": "6586206d-35fc-4aa9-a8dd-440e88789122",
+					"_postman_id": "1a0d22d9-21b8-5c5a-a17f-1982712c381c",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1681,13 +1689,13 @@
 							}
 						}
 					],
-					"_postman_id": "84a0b304-2787-441c-9bb4-451435568d8e",
+					"_postman_id": "b7ea1755-69e7-5d21-a543-b2334bdf0c8b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1775,13 +1783,13 @@
 							}
 						}
 					],
-					"_postman_id": "d37faebc-bd00-4751-9144-16e488fee1b0",
+					"_postman_id": "c211a28a-3006-574a-ae61-f84af21b8480",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1843,7 +1851,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "f175d843-fdcd-4674-80da-6ab62a20f17f",
+			"_postman_id": "93bf9e34-3502-51ec-b8d9-9d26282b29c5",
 			"description": "Export jobs are asynchronous processes that are used to persist audience segment members to datasets."
 		},
 		{
@@ -1876,13 +1884,13 @@
 							}
 						}
 					],
-					"_postman_id": "d4505892-a374-4a2c-b21c-d48faad679e0",
+					"_postman_id": "5461ae40-b2a5-586f-a159-bdcba6515907",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -1988,13 +1996,13 @@
 							}
 						}
 					],
-					"_postman_id": "83eaa195-c191-46ce-a965-5b270e29f57b",
+					"_postman_id": "12e987dc-9c5c-547b-839f-c470c19785ed",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2086,13 +2094,13 @@
 							}
 						}
 					],
-					"_postman_id": "f0826bca-0452-4b12-8193-bc2506ba4fa4",
+					"_postman_id": "459f133c-d3b6-5ac6-bb0c-b70120e63313",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2187,13 +2195,13 @@
 							}
 						}
 					],
-					"_postman_id": "728aecb6-5cbc-4726-bcf9-28c6d90b3171",
+					"_postman_id": "556e4d3f-6af9-5fd1-a4e9-d9bd828014b2",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2292,13 +2300,13 @@
 							}
 						}
 					],
-					"_postman_id": "233e4a14-f43f-4f03-9b35-ade3a9fdb0a7",
+					"_postman_id": "afb61639-7b2c-5482-bbfe-e918d33ee46a",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2367,8 +2375,8 @@
 					"response": []
 				}
 			],
-			"_postman_id": "05aff350-4427-4dbb-a23f-1dbb1672d19c",
-			"description": "A segment definition includes a Profile Query Language (PQL) statement that defines how to subdivide a customer base for an audience segment."
+			"_postman_id": "84c37807-1465-509b-86f4-93402a9d6cf4",
+			"description": "A segment definition includes a Profile Query Language (PQL) statement that defines which profiles will be part of an audience segment."
 		},
 		{
 			"name": "PQL conversions",
@@ -2400,13 +2408,13 @@
 							}
 						}
 					],
-					"_postman_id": "ce4e07e0-68eb-4dbe-a500-41224b276dce",
+					"_postman_id": "04b1fb5d-79cd-5517-a4d7-dee197c008a0",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2468,7 +2476,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "a5065f3d-ca30-4776-8a24-2874b50b377a",
+			"_postman_id": "60393f0a-c39f-5289-9975-b49d716bc24c",
 			"description": "Convert Profile Query Language (PQL) formatting between `pql/json` and `pql/text`."
 		},
 		{
@@ -2501,13 +2509,13 @@
 							}
 						}
 					],
-					"_postman_id": "ec7565a5-10ee-4528-a850-f796c7fc8875",
+					"_postman_id": "4921b2c0-6c42-5c37-9611-7751f41bf9f9",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2550,7 +2558,7 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https://platform.adobe.io/data/core/ups/segment/jobs?snapshot.name={{snapshot.name}}&start={{start}}&limit={{limit}}&status={{status}}",
+							"raw": "https://platform.adobe.io/data/core/ups/segment/jobs?start={{start}}&limit={{limit}}&status={{status}}",
 							"protocol": "https",
 							"host": [
 								"platform",
@@ -2565,10 +2573,6 @@
 								"jobs"
 							],
 							"query": [
-								{
-									"key": "snapshot.name",
-									"value": "{{snapshot.name}}"
-								},
 								{
 									"key": "start",
 									"value": "{{start}}"
@@ -2613,13 +2617,13 @@
 							}
 						}
 					],
-					"_postman_id": "5f157980-0c14-4062-9c48-fc2b109a6bff",
+					"_postman_id": "a057591b-cd8c-5115-bd06-60d2f5e4a44f",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2718,13 +2722,13 @@
 							}
 						}
 					],
-					"_postman_id": "e5b34e52-4bf7-46ec-b451-c738deecc7f4",
+					"_postman_id": "b6a8dc4c-3ca0-5e35-b9e2-02b03430b371",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2819,13 +2823,13 @@
 							}
 						}
 					],
-					"_postman_id": "86825738-df4f-4372-a154-d0ca369a4903",
+					"_postman_id": "2e884a6b-f7c9-519f-a0a9-545465588b41",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -2894,8 +2898,8 @@
 					"response": []
 				}
 			],
-			"_postman_id": "a2794a2e-615a-480f-b35f-690d0114d516",
-			"description": "Segment jobs process previously established segment definitions against your profile store to generate an audience segment."
+			"_postman_id": "2640e179-c11a-5ae8-af91-f34f1f6a21e7",
+			"description": "Segment jobs process previously established segment definitions to generate an audience segment."
 		},
 		{
 			"name": "Previews",
@@ -2927,13 +2931,13 @@
 							}
 						}
 					],
-					"_postman_id": "1fe307e6-969c-4747-be1c-f5166d68c0bd",
+					"_postman_id": "eddb417f-8b1c-54f4-8439-7315f9e4db7e",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3017,13 +3021,13 @@
 							}
 						}
 					],
-					"_postman_id": "fea9a9f4-a458-4c8c-89be-65d0b1bd215d",
+					"_postman_id": "d223d7ca-8c97-5bfd-b299-f638930e18d7",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3120,13 +3124,13 @@
 							}
 						}
 					],
-					"_postman_id": "ec1751e2-425c-472f-b637-ca3b365c10a8",
+					"_postman_id": "83484996-5145-5a17-9ec6-66d94e1beb18",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3187,7 +3191,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "20366fc7-d214-44d2-a741-c352cba6bd99",
+			"_postman_id": "0d29d08a-7711-5d6c-82b9-0979e4600564",
 			"description": "Previews provide paginated lists of qualifying profiles for a segment definition."
 		},
 		{
@@ -3220,13 +3224,13 @@
 							}
 						}
 					],
-					"_postman_id": "a4f4f762-2c0b-42ae-83a6-d251aaa27563",
+					"_postman_id": "260ab306-175d-5849-ad56-0f25f6a5e7a8",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -3287,7 +3291,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "3e0f5203-0467-4db8-a4f3-236358eef479",
+			"_postman_id": "2fedcaca-f904-5a5d-b1ea-5efb7a8d9190",
 			"description": "Estimates provide statistical information on a segment definition, such as the projected audience size and confidence interval."
 		},
 		{
@@ -3320,13 +3324,13 @@
 							}
 						}
 					],
-					"_postman_id": "c6558e31-d3ce-4ad9-8086-926a5b4d014b",
+					"_postman_id": "adfdb80f-97b9-5075-95e9-7539776bd21c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionConfigList+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -3438,17 +3442,17 @@
 							}
 						}
 					],
-					"_postman_id": "4ed484ac-5ebd-4e57-ad4b-beace5ce6a2a",
+					"_postman_id": "dffd66d7-97b2-5cdb-91f4-69109ad4b0d9",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionConfig+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.projectionConfig+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -3557,13 +3561,13 @@
 							}
 						}
 					],
-					"_postman_id": "2bbefea8-62dc-4fc5-b551-2af3b845cc62",
+					"_postman_id": "0dddce68-1a9a-537b-b691-6314f68c0f9a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionConfig+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -3672,17 +3676,17 @@
 							}
 						}
 					],
-					"_postman_id": "5b20e27f-8b36-44fd-8de7-3f25b53df053",
+					"_postman_id": "fdd51f6c-21ce-5371-92c3-2edd85946624",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionConfig+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.projectionConfig+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -3792,7 +3796,7 @@
 							}
 						}
 					],
-					"_postman_id": "5d86959c-54ff-435b-aff2-fd1d57b2cf2f",
+					"_postman_id": "79bc5476-95fb-5e26-a638-a3950e4783af",
 					"request": {
 						"method": "DELETE",
 						"header": [
@@ -3878,7 +3882,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "76a24ada-10fb-4e1d-9326-f67584d2832b",
+			"_postman_id": "8409dc9a-7d0f-5b54-b1b3-f42b3bf16c5c",
 			"description": "Edge projection configurations determine what data should be projected to each edge."
 		},
 		{
@@ -3911,13 +3915,13 @@
 							}
 						}
 					],
-					"_postman_id": "6284b4ea-237b-4a1d-9024-2241718782ee",
+					"_postman_id": "055c7ad3-d3b1-56a7-aebb-9d18a7632721",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionDestinationList+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -4005,17 +4009,17 @@
 							}
 						}
 					],
-					"_postman_id": "2e1cb69e-8d6a-469e-b9a4-3a1a401ae40c",
+					"_postman_id": "82f2f6a0-57e7-52fe-9b0d-3c9c26f4ba97",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionDestination+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.projectionDestination+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -4118,13 +4122,13 @@
 							}
 						}
 					],
-					"_postman_id": "f316a87e-ea90-4abb-ae05-0429b741672e",
+					"_postman_id": "7a557e88-2e21-565f-a32b-b59527098fe2",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionDestination+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -4233,17 +4237,17 @@
 							}
 						}
 					],
-					"_postman_id": "b5bbc71a-80d7-43ca-bc92-fe4840e4dfec",
+					"_postman_id": "53f0e991-9de7-55d5-ad06-41c1256cffac",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.projectionDestination+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.projectionDestination+json; version=1"
 							},
 							{
 								"key": "Authorization",
@@ -4353,7 +4357,7 @@
 							}
 						}
 					],
-					"_postman_id": "f582a46b-2c80-47af-82d1-ea3b6a7237eb",
+					"_postman_id": "d057946e-5558-5608-8016-3d77f2f4c69e",
 					"request": {
 						"method": "DELETE",
 						"header": [
@@ -4439,7 +4443,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "3b03b271-9186-4239-bced-3a7492b64d74",
+			"_postman_id": "0c1791dc-932e-5561-95e4-b4b3b53cbcf5",
 			"description": "Edge projection destinations define where to route a projection that has been created or changed."
 		},
 		{
@@ -4472,13 +4476,13 @@
 							}
 						}
 					],
-					"_postman_id": "8695da53-c6e7-422c-be41-bcdd66b0dde5",
+					"_postman_id": "2061f3c0-9e2e-53eb-bc9d-278249267425",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4580,13 +4584,13 @@
 							}
 						}
 					],
-					"_postman_id": "eb3f531e-6e1b-461f-94e0-c802cdcd0b5b",
+					"_postman_id": "0ea1b5d1-0901-5788-be79-29648d3c0bb5",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4681,13 +4685,13 @@
 							}
 						}
 					],
-					"_postman_id": "14a59b5d-f882-4a58-a23d-fc9dc2168f5d",
+					"_postman_id": "6a25c7db-0703-58a5-9166-b3a003c6165c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4782,13 +4786,13 @@
 							}
 						}
 					],
-					"_postman_id": "39318fd7-4a1e-4acd-948d-3863139663ba",
+					"_postman_id": "fe305b86-3ee9-59cd-aac7-75e049ec3aef",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4890,13 +4894,13 @@
 							}
 						}
 					],
-					"_postman_id": "fb1232d9-7dbb-41a7-93d5-1cb6139fcff7",
+					"_postman_id": "4f3fb6ff-d072-5274-9dfb-f7b5bbe6152c",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -4998,13 +5002,13 @@
 							}
 						}
 					],
-					"_postman_id": "5fbae4f5-1a11-43b2-a5d5-4f8fca454a93",
+					"_postman_id": "548878e2-dd12-542e-9699-a4183cd0d6c7",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5073,7 +5077,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "cdeb798b-8c3b-43a5-93e8-63bf8eef74b3",
+			"_postman_id": "ed3aecc6-4bee-5fe2-b98c-4fca1a94360f",
 			"description": "Event types are context descriptors for time series events within Real-time Customer Profile."
 		},
 		{
@@ -5106,13 +5110,13 @@
 							}
 						}
 					],
-					"_postman_id": "45be50bd-f601-41cd-bf06-d13ff267ca1f",
+					"_postman_id": "8289cba1-9c0a-5e09-b144-6bb7ff281c5f",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5195,7 +5199,8 @@
 									"value": "{{value}}"
 								}
 							]
-						}
+						},
+						"description": "**Warning: The macros endpoint is deprecated.**"
 					},
 					"response": []
 				},
@@ -5226,13 +5231,13 @@
 							}
 						}
 					],
-					"_postman_id": "291669e3-9a28-4c3c-9d94-619d6c44238b",
+					"_postman_id": "21e8c83a-bdaf-5096-8406-07d17c6122da",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5296,7 +5301,8 @@
 								"config",
 								"macros"
 							]
-						}
+						},
+						"description": "**Warning: The macros endpoint is deprecated.**"
 					},
 					"response": []
 				},
@@ -5327,13 +5333,13 @@
 							}
 						}
 					],
-					"_postman_id": "f7662e50-5b33-4eed-ae32-ef6253e8f765",
+					"_postman_id": "3230252d-8e73-56e5-931a-ed1df6447f8a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5397,7 +5403,8 @@
 									"id": "macroId"
 								}
 							]
-						}
+						},
+						"description": "**Warning: The macros endpoint is deprecated.**"
 					},
 					"response": []
 				},
@@ -5428,13 +5435,13 @@
 							}
 						}
 					],
-					"_postman_id": "1587278d-461d-4a8d-8950-f5ca12dc616f",
+					"_postman_id": "348d4688-12b8-5ca5-922c-b320e2680117",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5505,7 +5512,8 @@
 									"id": "macroId"
 								}
 							]
-						}
+						},
+						"description": "**Warning: The macros endpoint is deprecated.**"
 					},
 					"response": []
 				},
@@ -5536,13 +5544,13 @@
 							}
 						}
 					],
-					"_postman_id": "50c32e5f-ec1e-461f-99c6-9930ddb576ee",
+					"_postman_id": "17fe2cda-2d23-525c-890c-f6df5d02d1f2",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5613,7 +5621,8 @@
 									"id": "macroId"
 								}
 							]
-						}
+						},
+						"description": "**Warning: The macros endpoint is deprecated.**"
 					},
 					"response": []
 				},
@@ -5644,13 +5653,13 @@
 							}
 						}
 					],
-					"_postman_id": "8244334c-1941-4c6e-b6a5-3d16fc5f0cd0",
+					"_postman_id": "965a38bd-fcd2-52c3-bb89-4f9ff304fa2d",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5714,13 +5723,14 @@
 									"id": "macroId"
 								}
 							]
-						}
+						},
+						"description": "**Warning: The macros endpoint is deprecated.**"
 					},
 					"response": []
 				}
 			],
-			"_postman_id": "31dd5e5d-eba8-4d2e-be2f-7b59f5766ac5",
-			"description": "Macros allow you to inject pre-computed fields and values into segment definitions. Values from different fields are added together and tested against the profile store as a single value. With macros, audience segments can be defined in more ways than would otherwise be available from isolated profile data fields."
+			"_postman_id": "7d4ac653-2a45-5294-b0b8-c3a70884eb0c",
+			"description": "Warning: The macros endpoint is deprecated."
 		},
 		{
 			"name": "Schedules",
@@ -5752,13 +5762,13 @@
 							}
 						}
 					],
-					"_postman_id": "ce1e579c-87af-47a3-a5b3-e86a25338423",
+					"_postman_id": "94991b2c-267e-5e57-9c86-5fe4b9d17511",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -5856,13 +5866,13 @@
 							}
 						}
 					],
-					"_postman_id": "0261fbeb-e0be-4a91-8af3-3d41143146fe",
+					"_postman_id": "7a5a1970-8387-546c-944d-4e21d3ea8a2f",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -5923,7 +5933,8 @@
 								"config",
 								"schedules"
 							]
-						}
+						},
+						"description": "The scheduler is updated periodically (approximately every 30 minutes), so changes to a schedule may not go into effect immediately."
 					},
 					"response": []
 				},
@@ -5954,13 +5965,13 @@
 							}
 						}
 					],
-					"_postman_id": "577e715d-2287-4fd1-be25-86f72fd78ebe",
+					"_postman_id": "4d98253a-bb69-5550-b860-096e7db393db",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6024,7 +6035,8 @@
 									"id": "SCHEDULE_ID"
 								}
 							]
-						}
+						},
+						"description": "The scheduler is updated periodically (approximately every 30 minutes), so changes to a schedule may not go into effect immediately."
 					},
 					"response": []
 				},
@@ -6055,13 +6067,13 @@
 							}
 						}
 					],
-					"_postman_id": "c1b8a0db-843a-4ce9-83e5-33a36d8ad3af",
+					"_postman_id": "d362dac3-3f88-58f1-9697-569eaaf38ca7",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6125,7 +6137,8 @@
 									"id": "SCHEDULE_ID"
 								}
 							]
-						}
+						},
+						"description": "The scheduler is updated periodically (approximately every 30 minutes), so changes to a schedule may not go into effect immediately."
 					},
 					"response": []
 				},
@@ -6156,13 +6169,13 @@
 							}
 						}
 					],
-					"_postman_id": "6d407214-fef2-4c4c-b122-ed11bfb37ab4",
+					"_postman_id": "15a82aef-d453-5a5b-8dd0-358382d143c2",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6231,7 +6244,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "843be537-dffd-48c2-9387-36abc258b62a",
+			"_postman_id": "0863a614-6cf7-5e0b-a7c7-c02168103554",
 			"description": "Create a recurring schedule to automatically run export jobs. A schedule can run at most once daily."
 		},
 		{
@@ -6264,13 +6277,13 @@
 							}
 						}
 					],
-					"_postman_id": "2bd60cb2-7cba-4b93-92c5-3c1f72aa6e63",
+					"_postman_id": "8308a26d-2271-5c5c-8c7e-73349908be0b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6369,13 +6382,13 @@
 							}
 						}
 					],
-					"_postman_id": "74e6d6d6-f216-42a4-b20e-7d823b28d443",
+					"_postman_id": "bb2fd37e-7bd2-5cae-8918-a0145842be7f",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6457,13 +6470,13 @@
 							}
 						}
 					],
-					"_postman_id": "205d33d6-69c0-4afd-93a1-bd378aa17579",
+					"_postman_id": "919c3ac3-ebe2-54ed-ab48-53037ff4ed9e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6551,13 +6564,13 @@
 							}
 						}
 					],
-					"_postman_id": "a668551a-d5c9-433b-b036-271475cea3f4",
+					"_postman_id": "9a3a15b8-1ff1-5060-864c-4d03e741e27c",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -6619,7 +6632,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "b4c1829e-cd78-4fea-87a3-fad1484cd734",
+			"_postman_id": "c7f23a7e-6efe-5c46-8296-c8c4bccd59d5",
 			"description": "Profile System Jobs allow you to delete profile fragments for a given dataset or batch."
 		}
 	]

--- a/apis/experience-platform/Sandbox API.postman_collection.json
+++ b/apis/experience-platform/Sandbox API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "816dac4a-8a98-4bf0-b0bb-d095b7826ae6",
+		"_postman_id": "846c110f-9f29-59df-86a9-577da6974451",
 		"name": "Sandbox API",
 		"description": "Adobe Experience Platform provides virtual sandbox environments which provide isolation and access control for Platform integrations. Sandboxes can be used for application lifecycle management, project management, and building customized development ecosystems.\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/foundation/sandbox-management\n  * Example of a complete path: https://<span>platform.adobe.io/data/foundation/sandbox-management/sandboxes\n\nRequired headers:\n  * All service calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these, see the <a href=\"https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md\">authentication tutorial</a>.\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "7bc46e42-30a9-4094-a1d9-76a019e2b105",
+					"_postman_id": "c0257e40-a836-5fbb-a353-152b4b808f33",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -85,14 +85,14 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -103,7 +103,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "c3cb2bf8-324d-4006-afb7-92bb1b1e1a47",
+			"_postman_id": "175eefa5-1e64-5b72-bd5a-7e1bf3a9be25",
 			"description": "Sandbox operations available to all users."
 		},
 		{
@@ -136,13 +136,13 @@
 							}
 						}
 					],
-					"_postman_id": "d461820f-ea33-4ed8-9f13-7dbd6fcdd682",
+					"_postman_id": "8783ad4c-c620-53bf-a5b3-f553243bd711",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
@@ -178,14 +178,14 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/sandboxTypes",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/sandboxTypes",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -222,13 +222,13 @@
 							}
 						}
 					],
-					"_postman_id": "0b400dcd-e1bb-423c-88a4-09858abf45fa",
+					"_postman_id": "2aaf713a-3210-5199-8182-efb766b1f56c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -275,14 +275,14 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/sandboxes?property={{property}}&orderBy={{orderBy}}",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes?property={{property}}&orderBy={{orderBy}}",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -329,13 +329,13 @@
 							}
 						}
 					],
-					"_postman_id": "b878b31e-69ff-4d85-91a0-23fcd334b980",
+					"_postman_id": "d24ae706-6494-52a4-8d0c-d816cce6c44b",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -382,14 +382,14 @@
 							"raw": "{{sandboxPayload}}"
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/sandboxes",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -426,13 +426,13 @@
 							}
 						}
 					],
-					"_postman_id": "d7e1ae72-3c01-476b-af7c-129b9e819eb0",
+					"_postman_id": "79095a1f-dd3b-50fc-846d-06818f52ac2d",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -479,14 +479,14 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -530,13 +530,13 @@
 							}
 						}
 					],
-					"_postman_id": "ed720000-c551-4e04-b122-1e3c4629a4aa",
+					"_postman_id": "dc752ffe-a94c-513b-8b8e-e266e852bbe5",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -583,14 +583,14 @@
 							"raw": "{{action}}"
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -634,13 +634,13 @@
 							}
 						}
 					],
-					"_postman_id": "adf5b1d7-43ba-4c10-a2ad-ef0030179685",
+					"_postman_id": "dfaf816e-d15f-589a-8ff6-936e6348f626",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -687,14 +687,14 @@
 							"raw": "{{action}}"
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -738,13 +738,13 @@
 							}
 						}
 					],
-					"_postman_id": "d0da7ddd-a41c-48d3-a2c8-2e620bab31ef",
+					"_postman_id": "c39c332b-e25a-5ab2-a391-083f325026d2",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -791,14 +791,14 @@
 							"formdata": []
 						},
 						"url": {
-							"raw": "https:///data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"raw": "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes/:sandboxName",
+							"protocol": "https",
 							"host": [
-								"https:"
+								"platform",
+								"adobe",
+								"io"
 							],
-							"port": "",
 							"path": [
-								"",
-								"",
 								"data",
 								"foundation",
 								"sandbox-management",
@@ -816,7 +816,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "bd831d87-e3a8-4ef9-89a3-6e23ed49116e",
+			"_postman_id": "d84120e7-7f9f-5ed2-acd3-a2e70829aca5",
 			"description": "Sandbox operations available only to admins. Sandbox admin privileges are managed through the <a href='https://adminconsole.adobe.com'>Adobe Admin Console</a>."
 		}
 	]

--- a/apis/experience-platform/Schema Registry API.postman_collection.json
+++ b/apis/experience-platform/Schema Registry API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e406ad76-f373-47be-922f-45fed8dcf9a9",
+		"_postman_id": "bb777741-9a36-5b13-a644-ce2fbe94421c",
 		"name": "Schema Registry API",
 		"description": "The Schema Registry API is used to access the Schema Library within Adobe Experience Platform. The registry provides a user interface and RESTful API from which all available library resources are accessible.\n\nRelated documentation:\n  * <a href=\"https://www.adobe.io/apis/experienceplatform/home/xdm/xdmservices.html#!api-specification/markdown/narrative/technical_overview/schema_registry/xdm_system/xdm_system_in_experience_platform.md\">XDM System in Adobe Experience Platform</a>\n  * <a href=\"https://www.adobe.io/apis/experienceplatform/home/xdm/xdmservices.html#!api-specification/markdown/narrative/technical_overview/schema_registry/schema_composition/schema_composition.md\">Basics of schema composition</a>\n  * <a href=\"https://www.adobe.io/apis/experienceplatform/home/xdm/xdmservices.html#!api-specification/markdown/narrative/technical_overview/schema_registry/schema_registry_developer_guide.md\">Schema Registry API developer guide</a>\n  * <a href=\"https://www.adobe.io/apis/experienceplatform/home/xdm/xdmservices.html#!api-specification/markdown/narrative/tutorials/schema_registry_api_tutorial/schema_registry_api_tutorial.md\">Create a schema using the Schema Registry API</a>\n  \nVisualize API calls with Postman (a free, third-party software):\n  * [Schema Registry API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Schema%20Registry%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io\n  * Base path for this API: /data/foundation/schemaregistry\n  * Example of a complete path for making a call to \"/stats\": https://<span>platform.adobe.io/data/foundation/schemaregistry/stats\n\nRequired headers:\n  * All service calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these, see the <a href=\"https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md\">authentication tutorial</a>.\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All GET requests to the Schema Registry require an `Accept` header to determine what data is returned by the system. See the <a href=\"https://www.adobe.io/apis/experienceplatform/home/xdm/xdmservices.html#!api-specification/markdown/narrative/technical_overview/schema_registry/schema_registry_developer_guide.md#accept-header\">section on Accept headers</a> in the Schema Registry developer guide for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "ac0e0030-eb72-48ae-9e88-9fadc2d135e3",
+					"_postman_id": "f6e4b669-2c98-5b97-b87d-a198cc34020c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -100,7 +100,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "475c906a-97b6-496d-a5bd-3a3746105926",
+			"_postman_id": "c87161d8-7e10-5e6b-a0ab-3f9bd2e834b9",
 			"description": "Returns {TENANT_ID} along with information regarding IMS Org usage of the Schema Registry such as resource counts, recently created resources, and class usage."
 		},
 		{
@@ -133,13 +133,13 @@
 							}
 						}
 					],
-					"_postman_id": "f0e4bdeb-2bd3-47eb-b5df-42b29fb89e4e",
+					"_postman_id": "c027216e-bd5a-56c2-aab4-e8b99a30883e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -250,13 +250,13 @@
 							}
 						}
 					],
-					"_postman_id": "b723088b-4ef3-4330-af34-924e92972716",
+					"_postman_id": "dbe4b6b6-04ec-5532-968c-be18fae99612",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -348,13 +348,13 @@
 							}
 						}
 					],
-					"_postman_id": "f301f874-d9b4-4b4c-a08b-2df263504f8b",
+					"_postman_id": "c67a057f-3aa4-5350-9bce-384773fb62c9",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -451,13 +451,13 @@
 							}
 						}
 					],
-					"_postman_id": "9dbe546d-5511-4197-a77e-3aef4e6dd674",
+					"_postman_id": "ae1de5b7-226a-5ba4-8968-e389b68181c5",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -554,13 +554,13 @@
 							}
 						}
 					],
-					"_postman_id": "6e149833-4441-4210-a161-c40f4f3fe18d",
+					"_postman_id": "8beb2ef8-75bf-5680-beec-de4c8239ee7f",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -657,13 +657,13 @@
 							}
 						}
 					],
-					"_postman_id": "39d995cd-3654-4b6e-8b6e-c76b4561a60c",
+					"_postman_id": "9f04d3ca-76e0-5151-9a62-765512f26b15",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -734,7 +734,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "628081af-55b2-44bd-bc4f-cd95034b6037",
+			"_postman_id": "fcf65445-ad3c-5e7e-a396-4c377bf65377",
 			"description": "Schemas provide an abstract definition of a real-world object along with constraints and expectations that can be applied and used to validate data."
 		},
 		{
@@ -767,13 +767,13 @@
 							}
 						}
 					],
-					"_postman_id": "2f843a58-11f8-4b5e-a82b-10a257ce8453",
+					"_postman_id": "0eece1e1-50a8-5487-b755-23cc914e05ce",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -883,13 +883,13 @@
 							}
 						}
 					],
-					"_postman_id": "e9603e01-d745-4e86-bfdf-bcb0efa53f01",
+					"_postman_id": "73f36867-8769-531a-871c-8289bc3e38f1",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -981,13 +981,13 @@
 							}
 						}
 					],
-					"_postman_id": "81085d56-548a-4a13-9d39-2be276d30fb5",
+					"_postman_id": "fbb50100-ed34-5802-931b-812a27535f0d",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1083,13 +1083,13 @@
 							}
 						}
 					],
-					"_postman_id": "79f46447-a0b6-4f2e-a55c-8b9fe720c9e6",
+					"_postman_id": "15fdd7d2-5559-5cf6-be7d-e62fadf5ce1b",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1186,13 +1186,13 @@
 							}
 						}
 					],
-					"_postman_id": "44551fb8-7bff-4a5d-b21a-7cbfb5973a56",
+					"_postman_id": "84290726-46cf-5f8f-85da-bd1dfafd0a59",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1289,13 +1289,13 @@
 							}
 						}
 					],
-					"_postman_id": "8c0a19f1-f448-49c7-bcb5-f06fa4de5382",
+					"_postman_id": "14bb844d-acab-5f1a-ab09-5cedd0df7c02",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1366,7 +1366,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "e7cdee37-b4df-460e-8eb7-f38a4a6fd30a",
+			"_postman_id": "9c7191d2-429f-553b-bc45-30ef1b049fc3",
 			"description": "A mixin is a reusable component that defines one or more fields to implement certain functions within a schema based on a compatible class."
 		},
 		{
@@ -1399,13 +1399,13 @@
 							}
 						}
 					],
-					"_postman_id": "6381757a-0fbb-4c34-9bf1-1e599f3df0eb",
+					"_postman_id": "130f5e94-3fbd-52db-ba2d-6e583d141ca1",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1515,13 +1515,13 @@
 							}
 						}
 					],
-					"_postman_id": "076d4ec7-b092-4bfc-ba04-40ef62ecda62",
+					"_postman_id": "223bada4-ebf9-514b-8456-aba5dad00f16",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1613,13 +1613,13 @@
 							}
 						}
 					],
-					"_postman_id": "dfce06b8-e1a7-4ec6-aa9b-8d8a3474d624",
+					"_postman_id": "21920bed-c175-5df5-b0b5-d3d372164435",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1715,13 +1715,13 @@
 							}
 						}
 					],
-					"_postman_id": "27ec55f3-6aa1-4ccc-b68f-c4204e508fa5",
+					"_postman_id": "4379620a-6dfc-518e-a33d-58437d5e4011",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1818,13 +1818,13 @@
 							}
 						}
 					],
-					"_postman_id": "32903625-4960-4ed5-a2ee-3d9de631f6d3",
+					"_postman_id": "afc476a4-2576-5148-99e3-2a1eec5eb0fe",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1921,13 +1921,13 @@
 							}
 						}
 					],
-					"_postman_id": "7f11b60d-f57a-4d8f-ac7f-c7b40af104c0",
+					"_postman_id": "17058df6-c8df-5eea-81d0-a79eaa10acaf",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -1998,7 +1998,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "569b00ed-c3fb-418a-afa6-b29fef7bc812",
+			"_postman_id": "90c13482-6550-5bac-8ee6-49c35a219923",
 			"description": "Classes define behavioral aspects of the data within the schema and describe the smallest number of common properties contained in all schemas that implement the same class."
 		},
 		{
@@ -2031,13 +2031,13 @@
 							}
 						}
 					],
-					"_postman_id": "534fd6dc-8e0b-4b82-aac4-226710baea69",
+					"_postman_id": "86185664-ca11-5632-a319-e0ae794a07e3",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2147,13 +2147,13 @@
 							}
 						}
 					],
-					"_postman_id": "509afcf9-8064-431f-9bbd-8b6b021f16d0",
+					"_postman_id": "82f6a5ce-2143-5c22-99f1-cafce68f0912",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2245,13 +2245,13 @@
 							}
 						}
 					],
-					"_postman_id": "bf2cec78-ad78-4698-827a-9681e0c34f4e",
+					"_postman_id": "8625d42a-cefb-5951-9f40-f133288fa4d6",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2347,13 +2347,13 @@
 							}
 						}
 					],
-					"_postman_id": "c592e120-0895-4849-ac15-49dafa4daaa3",
+					"_postman_id": "e48b06fd-f925-56bb-aa77-238552023518",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2450,13 +2450,13 @@
 							}
 						}
 					],
-					"_postman_id": "e3841e8b-55a4-44b8-b502-a884a3c5a838",
+					"_postman_id": "a936120f-27ff-5463-90f8-73fe3543c48a",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2553,13 +2553,13 @@
 							}
 						}
 					],
-					"_postman_id": "ccd7ae85-1ffb-46bd-83b6-6b40f3eb7ceb",
+					"_postman_id": "7731a224-73e6-5455-90e1-495ccee380a7",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2630,7 +2630,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "a2aea703-a1b2-44ae-9501-da4734a23fcb",
+			"_postman_id": "c1b6c5e3-f53c-5f47-9022-f2d6ea8115f8",
 			"description": "Data types are used as reference field types in classes or schemas to define complex types. Data types may define multiple sub-fields providing a consistent multi-field structure."
 		},
 		{
@@ -2663,13 +2663,13 @@
 							}
 						}
 					],
-					"_postman_id": "02c64648-bfab-405b-9f94-721703072896",
+					"_postman_id": "ed72b507-b0fc-53d4-a6b5-6d138d3e809e",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2761,13 +2761,13 @@
 							}
 						}
 					],
-					"_postman_id": "090d87f4-ae0e-4736-83f3-3e8910cd5086",
+					"_postman_id": "fc65ea0e-5cde-5dc3-8c8a-5e7ef2d5b666",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2859,13 +2859,13 @@
 							}
 						}
 					],
-					"_postman_id": "613566d1-21d2-40d6-81e5-c351f23c858e",
+					"_postman_id": "223d97df-055e-513c-aa20-f1e173ca8d35",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -2962,13 +2962,13 @@
 							}
 						}
 					],
-					"_postman_id": "5d754677-fb92-432b-843a-4e0648b83045",
+					"_postman_id": "e898fc15-fe9a-56f4-930f-6da0d0c87c0d",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3065,13 +3065,13 @@
 							}
 						}
 					],
-					"_postman_id": "1f58516d-f522-4183-8d0f-96f9cb639d01",
+					"_postman_id": "7d726040-fcbd-5958-b775-03a9103742a1",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3142,7 +3142,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "22a3d57b-299f-468b-bb34-d9e2e8182a70",
+			"_postman_id": "e093ab1f-167c-52ed-94d5-05426e519d73",
 			"description": "Schema descriptors are tenant-level metadata used to provide interpretive details on how data based on certain schemas may relate or interact with one another."
 		},
 		{
@@ -3175,13 +3175,13 @@
 							}
 						}
 					],
-					"_postman_id": "4b799e17-d48e-4071-a8ac-fa0444b67232",
+					"_postman_id": "fb3bae55-76e7-5aba-81b3-f1bd55b1eee3",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3284,13 +3284,13 @@
 							}
 						}
 					],
-					"_postman_id": "2fdb72ac-c65b-43f1-82c6-f5124b2734bd",
+					"_postman_id": "133e6a62-98f2-5016-89d9-cc9ac3e16621",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
@@ -3356,7 +3356,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "bddf977f-0e81-4546-acf4-d6a89930d5b3",
+			"_postman_id": "48e01f4a-b888-5153-9e4b-dbb81c750f14",
 			"description": "Union views aggregate the fields of all schemas that implement the same class (such as ExperienceEvent or Profile) into a single schema. They are used by Real-time Customer Profile to merge data together to form a \"single source of truth\" for an individual."
 		}
 	]

--- a/apis/experience-platform/Sensei Machine Learning API.postman_collection.json
+++ b/apis/experience-platform/Sensei Machine Learning API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "75b7c641-1eba-43df-9b4f-74bc52011523",
+		"_postman_id": "c123e0c2-4642-59a9-a4ef-4a8da44d99ae",
 		"name": "Sensei Machine Learning API",
 		"description": "Sensei Machine Learning API provides a mechanism for data scientists to organize and manage ML services from algorithm onboarding through experimentation and to service deployment.\n\nRelated documentation:\n  * [Data Science Workspace overview](https://www.adobe.io/apis/experienceplatform/home/data-science-workspace/dsw-overview.html)\n  * [Data Science Workspace terminology](https://www.adobe.io/apis/experienceplatform/home/data-science-workspace/dsw-overview.html#!api-specification/markdown/narrative/technical_overview/data_science_workspace_overview/dsw_overview.md#terminology)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [Sensei Machine Learning API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Sensei%20Machine%20Learning%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\n\nAPI paths: \n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/ \n  * Base path for this API: /data/sensei\n  * Example of a complete path: https://<span>platform.adobe.io/data/sensei/engines\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://www.adobe.io/apis/experienceplatform/home/permissions-and-sandboxes/permissions-and-sandboxes.html#!api-specification/markdown/narrative/technical_overview/sandboxes/sandboxes-overview.md) for more information.\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,13 +36,13 @@
 							}
 						}
 					],
-					"_postman_id": "f918303e-6f53-4e63-9f60-2b082ddcd828",
+					"_postman_id": "9093b4f9-d937-5d89-8d25-01228fb79a25",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=engineListing.v1.json"
 							},
 							{
 								"key": "x-gw-ims-org-id",
@@ -108,17 +108,17 @@
 							}
 						}
 					],
-					"_postman_id": "03209769-1a95-4e8c-9310-3c306258fe59",
+					"_postman_id": "4390b397-3bda-51cc-a943-1d0fdeab6b02",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=engine.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "multipart/form-data"
 							},
 							{
 								"key": "x-gw-ims-org-id",
@@ -239,13 +239,13 @@
 							}
 						}
 					],
-					"_postman_id": "8ffb24c7-49e3-44ec-8a95-957a159d8b23",
+					"_postman_id": "4a2206cf-a78a-521b-8ff7-d490326f93ed",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=enginesDockerRegistryInfo.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -326,13 +326,13 @@
 							}
 						}
 					],
-					"_postman_id": "85dfaa84-fd27-47d0-810f-6d35d8210b08",
+					"_postman_id": "8701b037-9eb8-5a21-bf0b-287815265f7a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=engine.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -419,17 +419,17 @@
 							}
 						}
 					],
-					"_postman_id": "220fa4fd-b81a-4803-9e31-4fd2af583f43",
+					"_postman_id": "fc17e727-d407-59b0-983d-d74b8d3b31a7",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=engine.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=engine.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -516,13 +516,13 @@
 							}
 						}
 					],
-					"_postman_id": "108b7ffd-9777-4337-a1dc-3b30478851bd",
+					"_postman_id": "549221d8-73e6-5f62-823f-53138d526f68",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -583,7 +583,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "c70cda2d-5a2b-41bb-aa80-86c94a82d3f5",
+			"_postman_id": "9eabedce-7ec4-5ebf-9850-51ea71d88fea",
 			"description": "Engines act as an umbrella entity holding all machine learning instances. This is tied to a Docker image, Java archive, or EGG file which contains machine  learning logic to train and score a Model."
 		},
 		{
@@ -616,13 +616,13 @@
 							}
 						}
 					],
-					"_postman_id": "c1c06afd-9e73-452c-be14-457300077f25",
+					"_postman_id": "7fd42962-5248-59bc-b36b-7aadfd9422df",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlInstanceListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -702,17 +702,17 @@
 							}
 						}
 					],
-					"_postman_id": "5282e0fc-320f-48dc-b436-8276181da06c",
+					"_postman_id": "96489f28-cfdc-51ac-86ce-7f1153903bd6",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlInstance.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlInstance.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -792,13 +792,13 @@
 							}
 						}
 					],
-					"_postman_id": "a78595e0-acec-4c59-ba67-f763c9c89d26",
+					"_postman_id": "bebc4515-a0ee-5aa6-96ae-fb1d3e4b6141",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -884,13 +884,13 @@
 							}
 						}
 					],
-					"_postman_id": "2fd37985-832f-43de-af4f-7fc1bf7ad04d",
+					"_postman_id": "34c98c9b-2d44-5a94-8976-56b592773f0a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlInstance.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -976,17 +976,17 @@
 							}
 						}
 					],
-					"_postman_id": "59291d53-ead8-408e-a981-d34ca00e442d",
+					"_postman_id": "054973dc-6349-50df-abe8-70c8335f63c6",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlInstance.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlInstance.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1072,13 +1072,13 @@
 							}
 						}
 					],
-					"_postman_id": "34a47aa6-e011-47a7-ab38-92ff766bad5a",
+					"_postman_id": "54299887-c7f5-5c6d-abdd-77437779ebae",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1138,7 +1138,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "7a3e7a0b-7843-4788-94bb-3002533c329c",
+			"_postman_id": "77f8a2cc-5418-5326-a590-3323ce60827b",
 			"description": "MLInstances represent the combination of a specific Engine with particular set  of configurations. An instance is often use-case specific for a customer or client."
 		},
 		{
@@ -1171,13 +1171,13 @@
 							}
 						}
 					],
-					"_postman_id": "cc3771bb-2064-475f-8ba7-8026a6d967ed",
+					"_postman_id": "7b663b49-5328-5b18-8442-d865ae14e856",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experimentListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1256,17 +1256,17 @@
 							}
 						}
 					],
-					"_postman_id": "ef186b67-c0ad-4dbf-a983-4d816b9a93c8",
+					"_postman_id": "883cc850-6996-5134-972b-22be4fbe91f5",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experiment.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experiment.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1345,13 +1345,13 @@
 							}
 						}
 					],
-					"_postman_id": "13e89eec-7c03-4ede-ae04-39d311bbc52a",
+					"_postman_id": "3a0943b7-029b-59e0-9b93-6a99963ea966",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1437,13 +1437,13 @@
 							}
 						}
 					],
-					"_postman_id": "b7c85925-91e1-47b3-8fe9-ee78cb1e056e",
+					"_postman_id": "c34ad78c-a3dc-5743-9263-90e31b6c30d6",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experiment.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1529,17 +1529,17 @@
 							}
 						}
 					],
-					"_postman_id": "f70feb74-ced8-4e5b-b49e-cb8ff056c63a",
+					"_postman_id": "e6b6c020-3b22-5494-a527-d7a3c235af9e",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experiment.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experiment.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1625,13 +1625,13 @@
 							}
 						}
 					],
-					"_postman_id": "7b9f1e3a-a83e-42f8-bb5d-4e719c5924b6",
+					"_postman_id": "cfd1125b-52f0-5a73-b118-d93773fcfbfb",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1717,13 +1717,13 @@
 							}
 						}
 					],
-					"_postman_id": "23c14f8e-0af3-46a1-ae1a-057c6b6c45c8",
+					"_postman_id": "ae45e0c2-79c9-5da5-8a96-b2267f706e31",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experimentRunListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1810,17 +1810,17 @@
 							}
 						}
 					],
-					"_postman_id": "f10592d2-c0e1-4004-8813-4043506f5e1f",
+					"_postman_id": "1dd3aea8-8c5b-5303-9157-bb6a9df2bc01",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experimentRun.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experimentRun.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -1907,13 +1907,13 @@
 							}
 						}
 					],
-					"_postman_id": "63c34d1c-5911-4ee4-a373-83faffdb5ea9",
+					"_postman_id": "75008178-a72c-50c2-85ee-94cea0199fb1",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experimentRun.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2005,13 +2005,13 @@
 							}
 						}
 					],
-					"_postman_id": "db4c1cf7-cdf6-4a11-ad53-bdd9bda8954e",
+					"_postman_id": "ad1b1d3a-884c-55fb-a366-ac48f7994f45",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=experimentRunStatus.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2078,7 +2078,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "c9b00dc0-2955-4ec1-a5e1-7af21d5353b8",
+			"_postman_id": "f816c697-5e09-544a-942e-2269757e5a2a",
 			"description": "A data scientist conducts multiple experiments to arrive at a high-performing Model while training. This can include changing datasets, features, learning parameters, and hardware."
 		},
 		{
@@ -2111,13 +2111,13 @@
 							}
 						}
 					],
-					"_postman_id": "ba8cfc43-a4d1-4243-b5e9-b6d56f73cf1e",
+					"_postman_id": "4567b76f-f00f-5e0e-a870-85935ee38b95",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=modelListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2197,17 +2197,17 @@
 							}
 						}
 					],
-					"_postman_id": "6ae3d5e6-4499-453b-9407-7edfa5edd377",
+					"_postman_id": "02863cfb-756d-5777-be9e-3067a04400e3",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=model.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "multipart/form-data"
 							},
 							{
 								"key": "Authorization",
@@ -2300,13 +2300,13 @@
 							}
 						}
 					],
-					"_postman_id": "466668b1-3bad-4dbb-ab5d-027981918a7e",
+					"_postman_id": "8e38579e-17e7-5f82-8703-3a29ab3e7982",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=model.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2393,17 +2393,17 @@
 							}
 						}
 					],
-					"_postman_id": "c6caed47-ccef-4567-b169-dc59d325a532",
+					"_postman_id": "171d4342-e320-545c-9845-213325a21350",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=model.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=model.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2490,13 +2490,13 @@
 							}
 						}
 					],
-					"_postman_id": "510774df-f0de-466d-aa41-9def0587c268",
+					"_postman_id": "b1b6964f-c46c-5ee7-af31-523d18207ed9",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2583,13 +2583,13 @@
 							}
 						}
 					],
-					"_postman_id": "f2ab3e56-073f-4e6e-85fc-372d5458a44b",
+					"_postman_id": "64817e45-bbe6-5060-8193-fa04ee8d27a2",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/octet-stream"
 							},
 							{
 								"key": "Authorization",
@@ -2676,13 +2676,13 @@
 							}
 						}
 					],
-					"_postman_id": "706724e6-5dc9-435c-84e6-c5e880d63357",
+					"_postman_id": "3ba98f4d-10bc-52be-8eda-7ea47ae59fe6",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=modelTranscodingListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2769,17 +2769,17 @@
 							}
 						}
 					],
-					"_postman_id": "f2ebf668-3192-48c1-b87f-3e701c37e7c0",
+					"_postman_id": "d142844d-ae5b-57d3-82c5-c4fe045a3ba6",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=modelTranscoding.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=modelTranscoding.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2866,13 +2866,13 @@
 							}
 						}
 					],
-					"_postman_id": "2847c57b-676f-4cf4-b43e-4ffa5ad1ebeb",
+					"_postman_id": "43f9c380-695e-563d-86be-1a87f19b559c",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=modelTranscoding.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -2938,7 +2938,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "1f8bf8d4-b552-4e33-b4a0-b608c4a564c4",
+			"_postman_id": "a0757203-7f89-5c54-880b-79d37a9343f6",
 			"description": "Allows machine learning Model management and registration (Model artifact that is created by the training process)."
 		},
 		{
@@ -2971,13 +2971,13 @@
 							}
 						}
 					],
-					"_postman_id": "63879267-3fa6-4ea7-81ab-08bbcb73b5b5",
+					"_postman_id": "5228eea6-f3de-530a-8c52-e45fa8ec94d2",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=insightListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3057,17 +3057,17 @@
 							}
 						}
 					],
-					"_postman_id": "e55bdda0-87b5-4864-b44e-ea64f34e36b0",
+					"_postman_id": "f14e1c48-74dd-593c-b114-d773f5634b29",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=insight.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=insight.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3147,13 +3147,13 @@
 							}
 						}
 					],
-					"_postman_id": "49952ccd-0c80-40e9-a248-49d25d2b242c",
+					"_postman_id": "1d8ac9f0-91aa-5af8-b383-f57b3f453674",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=insight.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3240,13 +3240,13 @@
 							}
 						}
 					],
-					"_postman_id": "cf182826-6fb3-47e4-9ce0-af7d5647b222",
+					"_postman_id": "cd9bc95d-5c3c-547b-82ac-80c34544fe8b",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=defaultMetricsListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3307,7 +3307,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "82447d5d-3795-4c10-b65a-78fa186fff9e",
+			"_postman_id": "a660b7cd-2935-55c8-b37f-bd4032775805",
 			"description": "Insights contain metrics which are used to empower a  data scientist to evaluate and choose optimal ML Models by displaying  relevant evaluation metrics."
 		},
 		{
@@ -3340,13 +3340,13 @@
 							}
 						}
 					],
-					"_postman_id": "16f17e10-7436-4fa7-97ee-b2e0cf06d57b",
+					"_postman_id": "76fddf82-f841-52b0-9375-fb2ef97f645a",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlServiceListing.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3426,17 +3426,17 @@
 							}
 						}
 					],
-					"_postman_id": "cf78b3e3-dadd-4f7b-96f4-6f85454e4333",
+					"_postman_id": "c495468b-56cd-5d2b-8d4c-796cf1001363",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlService.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlService.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3516,13 +3516,13 @@
 							}
 						}
 					],
-					"_postman_id": "3b6efcbe-9ea2-4bdf-a1a9-96c4fa228316",
+					"_postman_id": "0a4593b1-f094-50b3-a282-ef4478108b68",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3608,13 +3608,13 @@
 							}
 						}
 					],
-					"_postman_id": "66b66149-99f2-4dbc-8d10-7b3eadc95534",
+					"_postman_id": "32b1bd70-7121-5f77-a1e2-4ae129bdd667",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": ", application/vnd.adobe.platform.sensei+json;profile=mlService.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3700,17 +3700,17 @@
 							}
 						}
 					],
-					"_postman_id": "447c6aa4-a3bb-40df-8a1a-cb9c0f0a9d37",
+					"_postman_id": "87f22e35-4004-5cd6-868c-d68547b9d1be",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlService.v1.json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=mlService.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3796,13 +3796,13 @@
 							}
 						}
 					],
-					"_postman_id": "4d80954d-7531-4af7-8c93-8558ade71a5b",
+					"_postman_id": "9c58f442-f68d-5a16-a187-e056e7e48e17",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json"
 							},
 							{
 								"key": "Authorization",
@@ -3862,7 +3862,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "2cd15ce2-8917-4190-8298-c893190c9b31",
+			"_postman_id": "a5b1e3e9-9682-5885-b733-f728afc7a6fb",
 			"description": "TMLServices represent an MLInstance which has been published as a service."
 		}
 	]

--- a/apis/experience-platform/XDM Core Object Repository API.postman_collection.json
+++ b/apis/experience-platform/XDM Core Object Repository API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "726c6935-da42-4f37-9de7-2f5a73a42192",
+		"_postman_id": "83770a3d-f06c-580d-a930-e25d575dce62",
 		"name": "XDM Core Object Repository API",
 		"description": "Experience Data Model (XDM) Core Object Repository is an event-driven repository for XDM instances, fully integrated with Adobe Experience Platform. XDM Core Object Repository is part of Decisioning Service, which provides the ability to programmatically and intelligently select the ‘Next Best Experience’ from a set of available options for a given individual, deliver them to any channel or application, and perform reporting and analysis on those experiences. Decisioning Service is controlled by a number of interrelated business objects. The XDM Core Object Repository API allows you to access and manage those business objects within the repository. \n\nRelated documentation:\n  * [Decisioning Service overview](https://www.adobe.io/apis/experienceplatform/home/services/decisioning-service.html#!api-specification/markdown/narrative/technical_overview/decisioning-overview/decisioning-service-overview.md)\n  * [Managing Decisioning Service entities using APIs tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/decisioning_tutorial/decisioning_entities_api_tutorial.md)\n\nVisualize API calls with Postman (a free, third-party software):\n  * [XDM Core Object Repository API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/XDM%20Core%20Object%20Repository%20API.postman_collection.json)\n  * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n  * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)\n\nAPI paths:\n  * PLATFORM Gateway URL: https://<span>platform.adobe.io/\n  * Base path for this API: /data/core/xcore\n  * Example of a complete path: https://<span>platform.adobe.io/data/core/xcore\n\nRequired headers:\n  * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.io/apis/experienceplatform/home/tutorials/alltutorials.html#!api-specification/markdown/narrative/tutorials/authenticate_to_acp_tutorial/authenticate_to_acp_tutorial.md).\n  * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -36,17 +36,17 @@
 							}
 						}
 					],
-					"_postman_id": "bdd51615-bea9-447b-8ed6-4d11afc57e49",
+					"_postman_id": "cd0f1f60-a365-509e-9244-0ad123c25631",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.xcore.hal+json; schema='https://ns.adobe.com/experience/xcore/hal/results'"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.xcore.hal+json"
 							},
 							{
 								"key": "Authorization",
@@ -184,17 +184,17 @@
 							}
 						}
 					],
-					"_postman_id": "aa641679-7449-4a64-b64d-f27e289d2845",
+					"_postman_id": "149f2818-bbdc-501a-99fa-836fc7e925c0",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.xcore.hal+json; schema='https://ns.adobe.com/experience/xcore/hal/results'"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.xcore.hal+json"
 							},
 							{
 								"key": "Authorization",
@@ -300,7 +300,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "6f46d154-09ce-4364-8a3e-2f138c9d24d6",
+			"_postman_id": "9a13dc13-070c-5104-b6d6-41a1b1f9c945",
 			"description": "Core Queries against XDM instances."
 		},
 		{
@@ -333,17 +333,17 @@
 							}
 						}
 					],
-					"_postman_id": "d229365e-2d55-4586-acbb-1e33aaf8ed82",
+					"_postman_id": "2bebcbd8-0529-51ab-b36d-04c1f3e80284",
 					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.xcore.xdm.receipt+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/schema-instance+json; schema=\"{namespaceId1} {namespaceId2}\""
 							},
 							{
 								"key": "Authorization",
@@ -445,17 +445,17 @@
 							}
 						}
 					],
-					"_postman_id": "a6e7ca1d-68ae-4558-b443-df635d607322",
+					"_postman_id": "65423748-f7dc-508c-9ee5-6c48e8d85309",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/schema-instance+json; schema=\"{namespaceId1} {namespaceId2}\", application/vnd.adobe.platform.xcore.hal+json; schema=\"{namespaceId1} {namespaceId2}\""
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.xcore.hal+json"
 							},
 							{
 								"key": "Authorization",
@@ -569,17 +569,17 @@
 							}
 						}
 					],
-					"_postman_id": "35e01640-14de-4fd6-b501-791a5d7c35e7",
+					"_postman_id": "45e98142-2219-5c7a-92a4-51710090920c",
 					"request": {
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.xcore.xdm.receipt+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/schema-instance+json; schema=\"{namespaceId1} {namespaceId2}\""
 							},
 							{
 								"key": "Authorization",
@@ -693,17 +693,17 @@
 							}
 						}
 					],
-					"_postman_id": "3d07a051-686a-4aac-ae4e-ac1d55c5f431",
+					"_postman_id": "5ede45c5-f897-5fb5-b39d-e4c8f2e7fa8a",
 					"request": {
 						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.xcore.xdm.receipt+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.xcore.patch.hal+json; schema=\"{namespaceId1} {namespaceId2}\""
 							},
 							{
 								"key": "Authorization",
@@ -817,17 +817,17 @@
 							}
 						}
 					],
-					"_postman_id": "a914d0fd-039f-4bcf-8af8-fc57dfdf9dda",
+					"_postman_id": "a1b860b0-927e-52b0-9e7c-804b699e0c37",
 					"request": {
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "application/vnd.adobe.platform.xcore.xdm.receipt+json; version=1"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.xcore.hal+json"
 							},
 							{
 								"key": "Authorization",
@@ -915,7 +915,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "a8fe9691-207f-4a4b-8153-dc8fddd3fbb8",
+			"_postman_id": "662e54d4-ca68-5f22-bde4-4aab833cb42e",
 			"description": "Perform CRUD operations to add, edit, update, delete, and view instances via the primary `instanceId`."
 		},
 		{
@@ -948,17 +948,17 @@
 							}
 						}
 					],
-					"_postman_id": "2fa97e1f-ea34-48fe-bd37-8b07178267ec",
+					"_postman_id": "35bab06a-6c12-5117-8b4b-52e41106e197",
 					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/vnd.adobe.xed+json"
+								"value": "*, application/vnd.adobe.platform.xcore.home.hal+json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json"
+								"value": "application/vnd.adobe.platform.xcore.hal+json"
 							},
 							{
 								"key": "Authorization",
@@ -1045,7 +1045,7 @@
 					"response": []
 				}
 			],
-			"_postman_id": "c1f0980c-05ee-4277-8843-8908df6edb55",
+			"_postman_id": "4951790a-e6cf-5fe3-ac3d-e46366c94026",
 			"description": "Home document for an IMS Organization. The home document is a HAL (Hypermedia Access Language) document which can be used as the hypermedia home directory for the IMS Organization specified. It lists relevant HAL links that can be traversed and also lists all of the containers belonging to the Org."
 		}
 	]


### PR DESCRIPTION
AEP Swagger Specs to Postman Collections conversion (2020-03-23)

Note that this PR should now stabilize the Postman IDs (Collections, Folder, Request) so they no longer add noise to the request, unless something about the actual entity changed in the Swagger spec (for example, if the name of a Folder changes, or the path of Request). Changes in parameters, headers, accepts, etc. will not result in a change of postman id.

