### PR TITLE
Update pre-request scripts to mitigate concurrent modification issue while removing blank headers

### DIFF
--- a/Postman Collections/CDP Namespaces and Schemas Utility/Namespaces and Schemas Autogeneration Utility.postman_collection.json
+++ b/Postman Collections/CDP Namespaces and Schemas Utility/Namespaces and Schemas Autogeneration Utility.postman_collection.json
@@ -201,7 +201,7 @@
 						"exec": [
 							"/** Begin Adobe-provided Pre-Request Scripts **/",
 							"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-							"pm.request.headers.each(header => {",
+							"pm.request.forEachHeader(header => {",
 							"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 							"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 							"    }",
@@ -292,7 +292,7 @@
 						"exec": [
 							"/** Begin Adobe-provided Pre-Request Scripts **/",
 							"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-							"pm.request.headers.each(header => {",
+							"pm.request.forEachHeader(header => {",
 							"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 							"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 							"    }",

--- a/apis/Adobe Experience Platform.postman_collection.json
+++ b/apis/Adobe Experience Platform.postman_collection.json
@@ -18,7 +18,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -96,7 +96,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -185,7 +185,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -290,7 +290,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -392,7 +392,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -537,7 +537,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -628,7 +628,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -786,7 +786,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -882,7 +882,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -980,7 +980,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1078,7 +1078,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1176,7 +1176,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1281,7 +1281,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1386,7 +1386,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1477,7 +1477,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1573,7 +1573,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1671,7 +1671,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1769,7 +1769,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1867,7 +1867,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -1976,7 +1976,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2057,7 +2057,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2130,7 +2130,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2232,7 +2232,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2327,7 +2327,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2426,7 +2426,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2532,7 +2532,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2637,7 +2637,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2729,7 +2729,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2826,7 +2826,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -2921,7 +2921,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3014,7 +3014,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3099,7 +3099,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3204,7 +3204,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3315,7 +3315,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3433,7 +3433,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3534,7 +3534,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3660,7 +3660,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3770,7 +3770,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3857,7 +3857,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -3936,7 +3936,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4021,7 +4021,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4120,7 +4120,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4205,7 +4205,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4291,7 +4291,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4377,7 +4377,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4471,7 +4471,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4563,7 +4563,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4648,7 +4648,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4749,7 +4749,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4835,7 +4835,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -4931,7 +4931,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5021,7 +5021,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5128,7 +5128,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5211,7 +5211,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5298,7 +5298,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5388,7 +5388,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5482,7 +5482,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5582,7 +5582,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5665,7 +5665,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5752,7 +5752,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5842,7 +5842,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -5936,7 +5936,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6036,7 +6036,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6119,7 +6119,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6206,7 +6206,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6296,7 +6296,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6390,7 +6390,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6490,7 +6490,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6573,7 +6573,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6660,7 +6660,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6750,7 +6750,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6844,7 +6844,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -6944,7 +6944,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7037,7 +7037,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7125,7 +7125,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7214,7 +7214,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7315,7 +7315,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7399,7 +7399,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7487,7 +7487,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7578,7 +7578,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7684,7 +7684,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7771,7 +7771,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7865,7 +7865,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -7968,7 +7968,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8053,7 +8053,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8141,7 +8141,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8230,7 +8230,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8320,7 +8320,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8420,7 +8420,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8519,7 +8519,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8622,7 +8622,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8707,7 +8707,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8795,7 +8795,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8893,7 +8893,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -8991,7 +8991,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9078,7 +9078,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9172,7 +9172,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9275,7 +9275,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9360,7 +9360,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9454,7 +9454,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9539,7 +9539,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9627,7 +9627,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9725,7 +9725,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9823,7 +9823,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9908,7 +9908,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -9996,7 +9996,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10094,7 +10094,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10197,7 +10197,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10307,7 +10307,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10419,7 +10419,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10519,7 +10519,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10596,7 +10596,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10681,7 +10681,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10765,7 +10765,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10857,7 +10857,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -10943,7 +10943,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11040,7 +11040,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11153,7 +11153,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11251,7 +11251,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11364,7 +11364,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11473,7 +11473,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11566,7 +11566,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11660,7 +11660,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11760,7 +11760,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11849,7 +11849,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -11949,7 +11949,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12038,7 +12038,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12138,7 +12138,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12246,7 +12246,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12335,7 +12335,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12443,7 +12443,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12529,7 +12529,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12618,7 +12618,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12711,7 +12711,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12804,7 +12804,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -12903,7 +12903,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13003,7 +13003,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13092,7 +13092,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13192,7 +13192,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13281,7 +13281,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13375,7 +13375,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13474,7 +13474,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13575,7 +13575,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13676,7 +13676,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13777,7 +13777,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13878,7 +13878,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -13970,7 +13970,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14045,7 +14045,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14136,7 +14136,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14223,7 +14223,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14330,7 +14330,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14415,7 +14415,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14510,7 +14510,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14610,7 +14610,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14733,7 +14733,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14824,7 +14824,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -14924,7 +14924,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15034,7 +15034,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15145,7 +15145,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15242,7 +15242,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15342,7 +15342,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15446,7 +15446,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15550,7 +15550,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15669,7 +15669,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15774,7 +15774,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15880,7 +15880,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -15996,7 +15996,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16111,7 +16111,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16208,7 +16208,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16308,7 +16308,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16408,7 +16408,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16512,7 +16512,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16627,7 +16627,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16706,7 +16706,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16789,7 +16789,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16875,7 +16875,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -16965,7 +16965,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17061,7 +17061,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17167,7 +17167,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17261,7 +17261,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17352,7 +17352,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17453,7 +17453,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17554,7 +17554,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17649,7 +17649,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17738,7 +17738,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17874,7 +17874,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -17960,7 +17960,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18066,7 +18066,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18172,7 +18172,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18283,7 +18283,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18386,7 +18386,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18498,7 +18498,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18608,7 +18608,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18692,7 +18692,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18797,7 +18797,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -18900,7 +18900,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19012,7 +19012,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19122,7 +19122,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19218,7 +19218,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19301,7 +19301,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19386,7 +19386,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19481,7 +19481,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19558,7 +19558,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19643,7 +19643,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19739,7 +19739,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19828,7 +19828,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -19905,7 +19905,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20003,7 +20003,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20094,7 +20094,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20189,7 +20189,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20288,7 +20288,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20387,7 +20387,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20497,7 +20497,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20584,7 +20584,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20693,7 +20693,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20789,7 +20789,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20875,7 +20875,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -20969,7 +20969,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21063,7 +21063,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21163,7 +21163,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21272,7 +21272,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21367,7 +21367,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21453,7 +21453,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21547,7 +21547,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21641,7 +21641,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21741,7 +21741,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21825,7 +21825,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -21922,7 +21922,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22030,7 +22030,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22125,7 +22125,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22211,7 +22211,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22305,7 +22305,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22399,7 +22399,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22499,7 +22499,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22607,7 +22607,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22702,7 +22702,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22788,7 +22788,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22882,7 +22882,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -22976,7 +22976,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23076,7 +23076,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23185,7 +23185,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23279,7 +23279,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23366,7 +23366,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23460,7 +23460,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23560,7 +23560,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23668,7 +23668,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23763,7 +23763,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23855,7 +23855,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -23949,7 +23949,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24043,7 +24043,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24143,7 +24143,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24245,7 +24245,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24342,7 +24342,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24434,7 +24434,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24527,7 +24527,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24625,7 +24625,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24726,7 +24726,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24818,7 +24818,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24910,7 +24910,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -24995,7 +24995,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25090,7 +25090,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25192,7 +25192,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25284,7 +25284,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25375,7 +25375,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25474,7 +25474,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25569,7 +25569,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25652,7 +25652,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25747,7 +25747,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25832,7 +25832,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -25926,7 +25926,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26020,7 +26020,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26130,7 +26130,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26228,7 +26228,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26319,7 +26319,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26414,7 +26414,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26503,7 +26503,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26593,7 +26593,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26687,7 +26687,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26780,7 +26780,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26872,7 +26872,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -26968,7 +26968,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27069,7 +27069,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27164,7 +27164,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27275,7 +27275,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27385,7 +27385,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27491,7 +27491,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27582,7 +27582,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27704,7 +27704,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27794,7 +27794,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -27916,7 +27916,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28012,7 +28012,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28103,7 +28103,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28193,7 +28193,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28282,7 +28282,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28368,7 +28368,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28470,7 +28470,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28560,7 +28560,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28686,7 +28686,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28776,7 +28776,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28890,7 +28890,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -28980,7 +28980,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29114,7 +29114,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29204,7 +29204,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29338,7 +29338,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29428,7 +29428,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29542,7 +29542,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29632,7 +29632,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29762,7 +29762,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29852,7 +29852,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -29958,7 +29958,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30054,7 +30054,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30145,7 +30145,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30235,7 +30235,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30324,7 +30324,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30416,7 +30416,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30507,7 +30507,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30597,7 +30597,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30692,7 +30692,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30783,7 +30783,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30873,7 +30873,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -30955,7 +30955,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31051,7 +31051,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31142,7 +31142,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31232,7 +31232,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31321,7 +31321,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31413,7 +31413,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31505,7 +31505,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31598,7 +31598,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31690,7 +31690,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31788,7 +31788,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31902,7 +31902,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -31992,7 +31992,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32083,7 +32083,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32180,7 +32180,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32270,7 +32270,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32368,7 +32368,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32459,7 +32459,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32549,7 +32549,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32638,7 +32638,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32730,7 +32730,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32822,7 +32822,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -32914,7 +32914,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33006,7 +33006,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33098,7 +33098,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33190,7 +33190,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33286,7 +33286,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33377,7 +33377,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33467,7 +33467,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33556,7 +33556,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33654,7 +33654,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33745,7 +33745,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33835,7 +33835,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -33924,7 +33924,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34016,7 +34016,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34107,7 +34107,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34199,7 +34199,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34291,7 +34291,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34383,7 +34383,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34476,7 +34476,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34568,7 +34568,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34660,7 +34660,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34751,7 +34751,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34844,7 +34844,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -34935,7 +34935,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35026,7 +35026,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35118,7 +35118,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35211,7 +35211,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35303,7 +35303,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35395,7 +35395,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35486,7 +35486,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35578,7 +35578,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35671,7 +35671,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35763,7 +35763,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35855,7 +35855,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -35946,7 +35946,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36052,7 +36052,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36148,7 +36148,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36239,7 +36239,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36329,7 +36329,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36418,7 +36418,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36552,7 +36552,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36643,7 +36643,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36735,7 +36735,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36827,7 +36827,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -36919,7 +36919,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37011,7 +37011,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37118,7 +37118,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37224,7 +37224,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37320,7 +37320,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37430,7 +37430,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37521,7 +37521,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37623,7 +37623,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37720,7 +37720,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37811,7 +37811,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37901,7 +37901,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -37990,7 +37990,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38096,7 +38096,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38202,7 +38202,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38308,7 +38308,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38414,7 +38414,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38510,7 +38510,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38608,7 +38608,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38705,7 +38705,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38795,7 +38795,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38889,7 +38889,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -38954,7 +38954,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39082,7 +39082,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39160,7 +39160,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39244,7 +39244,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39336,7 +39336,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39430,7 +39430,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39507,7 +39507,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39592,7 +39592,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39679,7 +39679,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39762,7 +39762,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39853,7 +39853,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -39946,7 +39946,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40022,7 +40022,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40106,7 +40106,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40193,7 +40193,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40276,7 +40276,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40367,7 +40367,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40454,7 +40454,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40538,7 +40538,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40630,7 +40630,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40719,7 +40719,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40815,7 +40815,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40892,7 +40892,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -40990,7 +40990,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41074,7 +41074,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41166,7 +41166,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41254,7 +41254,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41338,7 +41338,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41422,7 +41422,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41514,7 +41514,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41609,7 +41609,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41686,7 +41686,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41771,7 +41771,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41855,7 +41855,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -41945,7 +41945,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -42022,7 +42022,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -42107,7 +42107,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -42194,7 +42194,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -42277,7 +42277,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",
@@ -42368,7 +42368,7 @@
 										"exec": [
 											"/** Begin Adobe-provided Pre-Request Scripts **/",
 											"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-											"pm.request.headers.each(header => {",
+											"pm.request.forEachHeader(header => {",
 											"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 											"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 											"    }",

--- a/apis/experience-platform/Access Control API.postman_collection.json
+++ b/apis/experience-platform/Access Control API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -106,7 +106,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Audit Query API (Beta).postman_collection.json
+++ b/apis/experience-platform/Audit Query API (Beta).postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -134,7 +134,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Catalog Service API.postman_collection.json
+++ b/apis/experience-platform/Catalog Service API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -174,7 +174,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -271,7 +271,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -439,7 +439,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -545,7 +545,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -649,7 +649,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -753,7 +753,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -857,7 +857,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -969,7 +969,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1084,7 +1084,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1181,7 +1181,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1287,7 +1287,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1391,7 +1391,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1495,7 +1495,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1599,7 +1599,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1720,7 +1720,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1807,7 +1807,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1883,7 +1883,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Data Access API.postman_collection.json
+++ b/apis/experience-platform/Data Access API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -123,7 +123,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -231,7 +231,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -347,7 +347,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -462,7 +462,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -564,7 +564,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Data Ingestion API.postman_collection.json
+++ b/apis/experience-platform/Data Ingestion API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -119,7 +119,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -216,7 +216,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -306,7 +306,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -416,7 +416,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -532,7 +532,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -656,7 +656,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -766,7 +766,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -901,7 +901,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Data Prep API.postman_collection.json
+++ b/apis/experience-platform/Data Prep API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -111,7 +111,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -199,7 +199,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -294,7 +294,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -402,7 +402,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -492,7 +492,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -583,7 +583,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -674,7 +674,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -777,7 +777,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -874,7 +874,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -968,7 +968,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Dataset Service API.postman_collection.json
+++ b/apis/experience-platform/Dataset Service API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -114,7 +114,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -216,7 +216,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -311,7 +311,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Destination Authoring API.postman_collection.json
+++ b/apis/experience-platform/Destination Authoring API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -111,7 +111,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -203,7 +203,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -302,7 +302,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -401,7 +401,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -507,7 +507,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -599,7 +599,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -691,7 +691,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -790,7 +790,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -889,7 +889,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -995,7 +995,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1087,7 +1087,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1179,7 +1179,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1278,7 +1278,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1377,7 +1377,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1483,7 +1483,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1575,7 +1575,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1667,7 +1667,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1766,7 +1766,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1865,7 +1865,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1971,7 +1971,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2073,7 +2073,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2170,7 +2170,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2264,7 +2264,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2371,7 +2371,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2464,7 +2464,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2557,7 +2557,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2657,7 +2657,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Flow Service API.postman_collection.json
+++ b/apis/experience-platform/Flow Service API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -131,7 +131,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -221,7 +221,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -318,7 +318,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -416,7 +416,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -515,7 +515,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -620,7 +620,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -725,7 +725,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -821,7 +821,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -925,7 +925,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1037,7 +1037,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1127,7 +1127,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1224,7 +1224,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1327,7 +1327,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1431,7 +1431,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1527,7 +1527,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1631,7 +1631,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1743,7 +1743,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1833,7 +1833,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1937,7 +1937,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2027,7 +2027,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2124,7 +2124,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2227,7 +2227,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2331,7 +2331,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2421,7 +2421,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2518,7 +2518,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2621,7 +2621,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Identity Service.postman_collection.json
+++ b/apis/experience-platform/Identity Service.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -141,7 +141,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -265,7 +265,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -370,7 +370,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -494,7 +494,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -606,7 +606,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -729,7 +729,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -837,7 +837,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -923,7 +923,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1013,7 +1013,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1106,7 +1106,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1203,7 +1203,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1298,7 +1298,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Observability Insights API.postman_collection.json
+++ b/apis/experience-platform/Observability Insights API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -121,7 +121,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Policy Service API.postman_collection.json
+++ b/apis/experience-platform/Policy Service API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -128,7 +128,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -226,7 +226,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -335,7 +335,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -433,7 +433,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -539,7 +539,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -656,7 +656,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -754,7 +754,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -871,7 +871,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -962,7 +962,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1060,7 +1060,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1158,7 +1158,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1256,7 +1256,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1361,7 +1361,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1470,7 +1470,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1568,7 +1568,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1677,7 +1677,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1775,7 +1775,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1874,7 +1874,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1979,7 +1979,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2089,7 +2089,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2195,7 +2195,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2305,7 +2305,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2411,7 +2411,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2509,7 +2509,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2592,7 +2592,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Privacy Service API.postman_collection.json
+++ b/apis/experience-platform/Privacy Service API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -112,7 +112,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -228,7 +228,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -318,7 +318,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Query Service API.postman_collection.json
+++ b/apis/experience-platform/Query Service API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -131,7 +131,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -265,7 +265,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -362,7 +362,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -473,7 +473,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -591,7 +591,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -713,7 +713,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -817,7 +817,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -928,7 +928,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1039,7 +1039,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1150,7 +1150,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1280,7 +1280,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1392,7 +1392,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1509,7 +1509,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1633,7 +1633,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1759,7 +1759,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1863,7 +1863,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1974,7 +1974,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2085,7 +2085,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2196,7 +2196,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Reactor API.postman_collection.json
+++ b/apis/experience-platform/Reactor API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -135,7 +135,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -236,7 +236,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -368,7 +368,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -463,7 +463,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -595,7 +595,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -697,7 +697,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -798,7 +798,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -893,7 +893,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -987,7 +987,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1082,7 +1082,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1194,7 +1194,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1289,7 +1289,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1425,7 +1425,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1520,7 +1520,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1644,7 +1644,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1739,7 +1739,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1883,7 +1883,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1978,7 +1978,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2122,7 +2122,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2217,7 +2217,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2341,7 +2341,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2436,7 +2436,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2576,7 +2576,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2671,7 +2671,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2787,7 +2787,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2889,7 +2889,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2990,7 +2990,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3085,7 +3085,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3179,7 +3179,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3281,7 +3281,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3382,7 +3382,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3477,7 +3477,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3578,7 +3578,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3679,7 +3679,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3774,7 +3774,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3862,7 +3862,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3964,7 +3964,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4065,7 +4065,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4160,7 +4160,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4254,7 +4254,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4356,7 +4356,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4458,7 +4458,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4561,7 +4561,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4663,7 +4663,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4772,7 +4772,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4896,7 +4896,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4991,7 +4991,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5092,7 +5092,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5194,7 +5194,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5289,7 +5289,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5398,7 +5398,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5499,7 +5499,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5594,7 +5594,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5688,7 +5688,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5790,7 +5790,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5892,7 +5892,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -5994,7 +5994,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6096,7 +6096,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6198,7 +6198,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6300,7 +6300,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6402,7 +6402,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6503,7 +6503,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6598,7 +6598,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6692,7 +6692,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6801,7 +6801,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6902,7 +6902,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -6997,7 +6997,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7091,7 +7091,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7193,7 +7193,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7289,7 +7289,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7391,7 +7391,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7493,7 +7493,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7595,7 +7595,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7698,7 +7698,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7795,7 +7795,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7892,7 +7892,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -7988,7 +7988,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8091,7 +8091,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8187,7 +8187,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8283,7 +8283,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8385,7 +8385,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8488,7 +8488,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8585,7 +8585,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8682,7 +8682,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8778,7 +8778,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8880,7 +8880,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -8983,7 +8983,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9080,7 +9080,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9177,7 +9177,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9273,7 +9273,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9389,7 +9389,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9491,7 +9491,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9611,7 +9611,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9712,7 +9712,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9821,7 +9821,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -9922,7 +9922,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10017,7 +10017,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10111,7 +10111,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10255,7 +10255,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10351,7 +10351,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10453,7 +10453,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10555,7 +10555,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10657,7 +10657,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10759,7 +10759,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10876,7 +10876,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -10992,7 +10992,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11094,7 +11094,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11195,7 +11195,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11290,7 +11290,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11384,7 +11384,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11500,7 +11500,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11616,7 +11616,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11732,7 +11732,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11848,7 +11848,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -11950,7 +11950,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -12058,7 +12058,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -12166,7 +12166,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -12274,7 +12274,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -12375,7 +12375,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Real-time Customer Profile API.postman_collection.json
+++ b/apis/experience-platform/Real-time Customer Profile API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -107,7 +107,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -195,7 +195,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -290,7 +290,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -385,7 +385,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -487,7 +487,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -603,7 +603,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -704,7 +704,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -805,7 +805,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -913,7 +913,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1021,7 +1021,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1122,7 +1122,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1217,7 +1217,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1362,7 +1362,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1453,7 +1453,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1565,7 +1565,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1683,7 +1683,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1802,7 +1802,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1917,7 +1917,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2037,7 +2037,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2156,7 +2156,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2250,7 +2250,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2363,7 +2363,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2478,7 +2478,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2598,7 +2598,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2717,7 +2717,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2822,7 +2822,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2910,7 +2910,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3004,7 +3004,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3105,7 +3105,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3191,7 +3191,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3285,7 +3285,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Sandbox API.postman_collection.json
+++ b/apis/experience-platform/Sandbox API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -119,7 +119,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -205,7 +205,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -313,7 +313,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -410,7 +410,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -515,7 +515,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -620,7 +620,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -725,7 +725,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Schema Registry API.postman_collection.json
+++ b/apis/experience-platform/Schema Registry API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -116,7 +116,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -235,7 +235,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -340,7 +340,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -431,7 +431,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -530,7 +530,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -629,7 +629,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -735,7 +735,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -854,7 +854,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -960,7 +960,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1051,7 +1051,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1150,7 +1150,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1249,7 +1249,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1355,7 +1355,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1449,7 +1449,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1557,7 +1557,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1675,7 +1675,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1780,7 +1780,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1871,7 +1871,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1970,7 +1970,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2069,7 +2069,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2175,7 +2175,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2293,7 +2293,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2398,7 +2398,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2489,7 +2489,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2588,7 +2588,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2687,7 +2687,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2793,7 +2793,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2911,7 +2911,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3016,7 +3016,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3114,7 +3114,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3213,7 +3213,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3312,7 +3312,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3418,7 +3418,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3537,7 +3537,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3640,7 +3640,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3732,7 +3732,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3831,7 +3831,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3937,7 +3937,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4049,7 +4049,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4157,7 +4157,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4259,7 +4259,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4358,7 +4358,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -4467,7 +4467,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Segmentation Service API.postman_collection.json
+++ b/apis/experience-platform/Segmentation Service API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -120,7 +120,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -218,7 +218,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -312,7 +312,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -413,7 +413,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -525,7 +525,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -623,7 +623,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -724,7 +724,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -829,7 +829,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -930,7 +930,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1018,7 +1018,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1120,7 +1120,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1240,7 +1240,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1345,7 +1345,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1446,7 +1446,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1547,7 +1547,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1642,7 +1642,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1732,7 +1732,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1835,7 +1835,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1935,7 +1935,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2035,7 +2035,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2139,7 +2139,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2238,7 +2238,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2340,7 +2340,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2442,7 +2442,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2550,7 +2550,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2655,7 +2655,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2776,7 +2776,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",

--- a/apis/experience-platform/Sensei Machine Learning API.postman_collection.json
+++ b/apis/experience-platform/Sensei Machine Learning API.postman_collection.json
@@ -19,7 +19,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -91,7 +91,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -222,7 +222,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -309,7 +309,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -402,7 +402,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -499,7 +499,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -599,7 +599,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -685,7 +685,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -775,7 +775,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -867,7 +867,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -959,7 +959,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1055,7 +1055,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1154,7 +1154,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1239,7 +1239,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1328,7 +1328,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1420,7 +1420,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1512,7 +1512,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1608,7 +1608,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1700,7 +1700,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1793,7 +1793,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1890,7 +1890,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -1988,7 +1988,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2094,7 +2094,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2180,7 +2180,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2283,7 +2283,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2376,7 +2376,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2473,7 +2473,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2566,7 +2566,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2659,7 +2659,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2752,7 +2752,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2849,7 +2849,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -2954,7 +2954,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3040,7 +3040,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3130,7 +3130,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3223,7 +3223,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3323,7 +3323,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3409,7 +3409,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3499,7 +3499,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3591,7 +3591,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3683,7 +3683,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",
@@ -3779,7 +3779,7 @@
 								"exec": [
 									"/** Begin Adobe-provided Pre-Request Scripts **/",
 									"// Do not send HTTP Headers with empty variables, as Postman will send the literal variable name",
-									"pm.request.headers.each(header => {",
+									"pm.request.forEachHeader(header => {",
 									"    if (header.value.startsWith(\"{{\") && header.value.endsWith(\"}}\")) {",
 									"        if (!pm.variables.get(header.value.substring(2, header.value.length - 2))) { pm.request.headers.remove(header.key); }",
 									"    }",


### PR DESCRIPTION
## Description

In Postman 10.7.1 for MacOS, `pm.request.headers.each()` fails when removing headers while iterating over them:
> TypeError: Cannot read properties of undefined (reading 'value')

Using [Request.forEachHeader()](https://www.postmanlabs.com/postman-collection/Request.html#forEachHeader) avoids that pitfall.  Other options would be operating on `pm.request.headers.members`, or calling `all()` or `map()` before `each()`, since either would result in an independent list of headers.

For reference, [Request.forEachHeader()](https://www.postmanlabs.com/postman-collection/Request.html#forEachHeader) internally calls `pm.request.headers.all().each(callback)`.

## Related Issue

#62 

## Motivation and Context

Fixes a TypeError that breaks this collection.

## How Has This Been Tested?

Manually and exhaustively with Postman.

## Screenshots (if appropriate):

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/648035/211994669-461cb858-687d-4aff-a3ac-9ad41deb21d3.png">

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/648035/211994752-4a8fcf34-087a-4cde-9e41-2e8d79fa1269.png">


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
